### PR TITLE
added scenarios after marking proposal to completed

### DIFF
--- a/src/resources/keywords/comment_module.robot
+++ b/src/resources/keywords/comment_module.robot
@@ -107,7 +107,7 @@ Main Thread "${e_THREAD_NUMBER}" Messages Should Be Empty
 Main Thread "${e_THREAD_NUMBER}" Should Have Like
   Wait Until Element Should Be Visible  ${COMMMENT_DIV}:eq(${e_THREAD_NUMBER})
   Set Focus To Element  ${COMMMENT_DIV}:eq(${e_THREAD_NUMBER})
-  Element Should Contain  ${COMMMENT_DIV}:eq(${e_THREAD_NUMBER}) [class*="ActionCommentButton"]:eq(1)  UNLIKE
+  Element Should Contain  ${COMMMENT_DIV}:eq(${e_THREAD_NUMBER}) [class*="ActionCommentButton"]:eq(1)  1
 
 #====================#
 #  INTERNAL KEYWORD  #

--- a/src/resources/keywords/governance_page.robot
+++ b/src/resources/keywords/governance_page.robot
@@ -78,17 +78,17 @@ User Submits Locked DGD
   Get Remaining Time To Execute Next Step
   Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
   Run Keyword If  "${e_RESPONSE}"=="Yes"
-  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(0)
+  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(0)  #Yes vote button
   ...  ELSE IF  "${e_RESPONSE}"=="No"
-  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(1)
+  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(1)  #No vote button
   ${t_salt}=  Get Element Attribute  ${GOVERNANCE_SIDE_PANEL} a:eq(0)  download
-  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} a:eq(0)
-  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(3)
+  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} a:eq(0)  #Download Json File button
+  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(2)  #confirm commit button
   Replace Salt File According To User Role  ${t_salt}  ${e_USER}
   User Submits Keystore Password
 
 "${e_USER}" Reveals Vote Via Salt File
-  Newly Created Proposal Should Be Visible On "Proposal" Tab
+  Newly Created Proposal Should Be Visible On "All" Tab
   Visit Newly Created Proposal And Click Next Action
   Get Remaining Time To Execute Next Step
   "Upload" "${e_USER}" Salt File

--- a/src/suite/endtoend/DAOGovernanceETest.robot
+++ b/src/suite/endtoend/DAOGovernanceETest.robot
@@ -106,6 +106,45 @@ Proposer Has Successfully Completed Milestone
   When "proposer" "Sets Proposal To Complete" On Newly Created Proposal
   Then Proposal Status Should Be "REVIEW"
 
-# Participant Has Successfully Voted For Completed Proposal
+Participant Has Successfully Voted No For Completed Proposal
+  [Setup]  Switch Browser  participant
+  Given User Is In "Governance" Page
+  When "participant" Votes "No" On Proposal
+  Then Vote Count Should Increase
 
-# Moderator Has Successfully Voted For Completed Proposal
+Proposer Has Successfully Voted Yes For Completed Proposal
+  [Setup]  Switch Browser  proposer
+  Given User Is In "Governance" Page
+  When "proposer" Votes "Yes" On Proposal
+  Then Vote Count Should Increase
+
+Moderator Has Successfully Voted Yes For Completed Proposal
+  [Setup]  Switch Browser  moderator
+  Given User Is In "Governance" Page
+  When "moderator" Votes "Yes" On Proposal
+  Then Vote Count Should Increase
+
+Participant Has Successfully Revealed Vote On Completed Proposal
+  [Setup]  Run Keywords  Sleep Until Timer Runs Out  REVEAL
+  ...  AND  Switch Browser  participant
+  Given User Is In "Governance" Page
+  When "participant" Reveals Vote Via Salt File
+  Then Vote Count Should Increase
+
+Moderator Has Successfully Revealed Vote On Completed Proposal
+  [Setup]  Switch Browser  moderator
+  Given User Is In "Governance" Page
+  When "moderator" Reveals Vote Via Salt File
+  Then Vote Count Should Increase
+
+Proposer Has Successfully Revealed Vote On Completed Proposal
+  [Setup]  Switch Browser  proposer
+  Given User Is In "Governance" Page
+  When "proposer" Reveals Vote Via Salt File
+  Then Vote Count Should Increase
+
+Proposer Has Successfully Claimed Vote Result On Reviewed Proposal
+  [Setup]  Sleep Until Timer Runs Out
+  Given User Is In "Governance" Page
+  When "porposer" "Claims Voting Result" On Newly Created Proposal
+  Then Proposal Status Should Be "ARCHIVED"


### PR DESCRIPTION
- vote
- reveal
- claim result
- assert proposal status to 'ARCHIVED'

#testcase
```
Proposer Has Successfully Created A Proposal
  [Setup]  "proposer" Account Has Successfully Locked DGD
  Given User Is In "GOVERNANCE" Page
  When "proposer" Creates A Governance Propsosal
  Then User Should Be Redirected To "GOVERNANCE" Page
  And Newly Created Proposal Should Be Visible On "Idea" Tab
  And Proposal Status Should Be "IDEA"

Moderator Has Successfully Endorsed Newly Created Proposal
  [Setup]  "moderator" Account Has Successfully Locked DGD
  Given User Is In "GOVERNANCE" Page
  When "moderator" "Endorses Proposal" On Newly Created Proposal
  Then User Should Be Able To Participate On Proposal
  And Proposal Status Should Be "DRAFT"

Participant Has Successfully Locked DGD
  [Setup]  "participant" Account Has Successfully Locked DGD
  Then User Should Be Redirected To "Governance" Page

Proposer Has Successfully Finalized Proposal
  [Setup]  Switch Browser  proposer
  Given User Is In "Governance" Page
  When "proposer" "finalizes Proposal" On Newly Created Proposal
  Then Proposal Status Should Be "DRAFT"

Moderator Has Successfully Approved Created Proposal
  [Setup]  Switch Browser  moderator
  Given User Is In "Governance" Page
  When "moderator" Approves Newly Drafted Proposal
  Then Proposal Status Should Be "DRAFT"

Proposer Has Successfully Claimed Approved Proposal
  [Setup]  Run Keywords  Sleep Until Timer Runs Out
  ...  AND  Switch Browser  proposer
  Given User Is In "Governance" Page
  When "porposer" "Claims Approved Proposal" On Newly Created Proposal
  Then Proposal Status Should Be "PROPOSAL"

Moderator Has Successfully Voted Yes On Proposal
  [Setup]  Switch Browser  moderator
  Given User Is In "Governance" Page
  When "moderator" Votes "Yes" On Proposal
  Then Vote Count Should Increase

Participant Has Successfully Voted No On Proposal
  [Setup]  Switch Browser  participant
  Given User Is In "Governance" Page
  When "participant" Votes "No" On Proposal
  Then Vote Count Should Increase

Proposer Has Successfully Voted Yes On Proposal
  [Setup]  Switch Browser  proposer
  Given User Is In "Governance" Page
  When "proposer" Votes "Yes" On Proposal
  Then Vote Count Should Increase

Moderator Has Successfully Revealed Vote To Proposal
  [Setup]  Run Keywords  Sleep Until Timer Runs Out  REVEAL
  ...  AND  Switch Browser  moderator
  Given User Is In "Governance" Page
  When "moderator" Reveals Vote Via Salt File
  Then Vote Count Should Increase

Participant Has Not Successfully Voted Using Modified Salt File
  [Setup]  Switch Browser  participant
  Given User Is In "Governance" Page
  When "participant" Uploads Modified Salt File
  Then Snackbox Should Contain "VM Exception"

Participant Has Successfully Revealed Vote To Proposal
  [Setup]  Run Keywords  Go Back To Dashboard Page
  ...  AND  Switch Browser  participant
  Given User Is In "Governance" Page
  When "participant" Reveals Vote Via Salt File
  Then Vote Count Should Increase

Proposer Has Successfully Revealed Vote To Proposal
  [Setup]  Switch Browser  proposer
  Given User Is In "Governance" Page
  When "proposer" Reveals Vote Via Salt File
  Then Vote Count Should Increase

Proposer Has Successfully Claimed Vote Result
  [Setup]  Sleep Until Timer Runs Out
  Given User Is In "Governance" Page
  When "porposer" "Claims Voting Result" On Newly Created Proposal
  Then Proposal Status Should Be "ONGOING"

Proposer Has Successfully Claimed Funding
  Given User Is In "Governance" Page
  When "proposer" "Claims Proposal Funding" On Newly Created Proposal
  Then Proposal Status Should Be "ONGOING"

Proposer Has Successfully Completed Milestone
  Given User Is In "Governance" Page
  When "proposer" "Sets Proposal To Complete" On Newly Created Proposal
  Then Proposal Status Should Be "REVIEW"

Participant Has Successfully Voted No For Completed Proposal
  [Setup]  Switch Browser  participant
  Given User Is In "Governance" Page
  When "participant" Votes "No" On Proposal
  Then Vote Count Should Increase

Proposer Has Successfully Voted Yes For Completed Proposal
  [Setup]  Switch Browser  proposer
  Given User Is In "Governance" Page
  When "proposer" Votes "Yes" On Proposal
  Then Vote Count Should Increase

Moderator Has Successfully Voted Yes For Completed Proposal
  [Setup]  Switch Browser  moderator
  Given User Is In "Governance" Page
  When "moderator" Votes "Yes" On Proposal
  Then Vote Count Should Increase

Participant Has Successfully Revealed Vote On Completed Proposal
  [Setup]  Run Keywords  Sleep Until Timer Runs Out  REVEAL
  ...  AND  Switch Browser  participant
  Given User Is In "Governance" Page
  When "participant" Reveals Vote Via Salt File
  Then Vote Count Should Increase

Moderator Has Successfully Revealed Vote On Completed Proposal
  [Setup]  Switch Browser  moderator
  Given User Is In "Governance" Page
  When "moderator" Reveals Vote Via Salt File
  Then Vote Count Should Increase

Proposer Has Successfully Revealed Vote On Completed Proposal
  [Setup]  Switch Browser  proposer
  Given User Is In "Governance" Page
  When "proposer" Reveals Vote Via Salt File
  Then Vote Count Should Increase

Proposer Has Successfully Claimed Vote Result On Reviewed Proposal
  [Setup]  Sleep Until Timer Runs Out
  Given User Is In "Governance" Page
  When "porposer" "Claims Voting Result" On Newly Created Proposal
  Then Proposal Status Should Be "ARCHIVED"
```

Tracker: https://tracker.digixdev.com/agiles/88-10/89-10?issue=DT-39