### PR TITLE
Mike/new/likeunlikemodule

### DIFF
--- a/src/resources/common/web_helper.robot
+++ b/src/resources/common/web_helper.robot
@@ -101,6 +101,12 @@ Add Console Logs To Suite Documentation
 #==========#
 Load JQuery Tool
   Execute Javascript  (document.onload=function() {var script = document.createElement('script'); script.setAttribute("type", "text/javascript"); script.setAttribute("src", "https://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"); document.getElementsByTagName("head")[0].appendChild(script);})();
+  :FOR  ${index}  IN RANGE  0  10
+  \  ${t_val}=  Run Keyword And Return Status
+  ...  Execute Javascript  return jQuery.active
+  \  Run Keyword If  ${t_val}
+  ...  Exit For Loop
+  ...  ELSE  Sleep  1 s
 
 Force Element Via jQuery
   [Arguments]  ${p_element}  ${p_action}

--- a/src/resources/keywords/comment_module.robot
+++ b/src/resources/keywords/comment_module.robot
@@ -5,13 +5,13 @@ Resource    ../variables/comment_constants.robot
 #========#
 #  WHEN  #
 #========#
-"${e_USER}" Posts Multiple Thread On Created Proposal
+"${e_USER}" Posts "${e_COUNT}" Thread On Created Proposal
   Switch Browser  ${e_USER}
   Go To Newly Created Proposal View Page
   Wait Until Element Should Be Visible  ${THREAD_SECTION}
   Set Selenium Speed  ${REMOTE_SPEED}
   ${t_list}=  Create List
-  :FOR  ${index}  IN RANGE  0  ${NUMBER_OF_THREADS}
+  :FOR  ${index}  IN RANGE  0  ${e_COUNT}
   \  ${t_time}=  Get Time  epoch
   \  ${t_value}=  Convert To String  ${t_time} - ${index} - thread
   \  Input Text  ${THREAD_FIELD}  ${t_value}
@@ -53,7 +53,7 @@ Resource    ../variables/comment_constants.robot
 "${e_USER}" Sorts Main Thread From "${e_SORTING}"
   Wait Until Element Should Be Visible  ${SORTING_DD}
   Set Focus To Element  ${SORTING_DD}
-  ${t_text}=  Get Text  ${COMMMENT_DIV}:eq(0)
+  ${t_text}=  Get Text  ${COMMMENT_DIV}:eq(0) ${COMMENT_POST}
   Set Suite Variable  ${s_THREAD_ONE_VALUE}  ${t_text}
   Select From List By Label  ${SORTING_DD}  ${e_SORTING}
 
@@ -88,11 +88,9 @@ User Shows All "${e_COMMENT_TYPE}" Comments
 All Thread Comments Should Be Visible
   :FOR  ${index}  ${value}  IN ENUMERATE  @{g_THREAD_VALUES}
   \  ${t_div}=  Set Variable  ${COMMMENT_DIV}:eq(${index}) ${COMMENT_POST}
-  \  Wait Until Element Should Be Visible  ${t_div}
   \  Wait Until ELement Should Contain  ${t_div}  ${value}
 
 Main Thread Should Be Sorted
-  Wait Until Element Should Be Visible  ${COMMMENT_DIV}:eq(0)
   Wait Until ELement Should Contain  ${COMMMENT_DIV}:eq(0)  ${s_THREAD_ONE_VALUE}
 
 All Comments Should Be Visible

--- a/src/resources/keywords/governance_page.robot
+++ b/src/resources/keywords/governance_page.robot
@@ -202,6 +202,7 @@ Go To Newly Created Proposal View Page
   Wait Until Element Should Be Visible  ${PROPOSAL_CARD}:eq(0) h2
   Wait Until ELement Should Contain  ${PROPOSAL_CARD}:eq(0) h2  ${g_GENERIC_VALUE}
   Hide SnackBar
+  Modify Element Attribute Via jQuery  ${GOVERNANCE_MENU}  display  none
   Wait And Click Element  ${PROPOSAL_CARD}:eq(0) ${VIEW_PROJECT_LINK}
 
 Visit Newly Created Proposal And Click "${e_ACTION}" Action

--- a/src/resources/keywords/like_unlike_module.robot
+++ b/src/resources/keywords/like_unlike_module.robot
@@ -1,0 +1,66 @@
+*** Settings ***
+Resource    ../variables/like_unlike_constants.robot
+
+*** Keywords ***
+#========#
+#  WHEN  #
+#========#
+User "${e_ACTION}" Newly Created Proposal In "${e_PAGE}" Page
+  Hide SnackBar
+  ${t_locator}=  Set Variable If  "${e_PAGE}"=="DASHBOARD"
+  ...  ${PROPOSAL_CARD}:eq(0) ${DASHBOARD_${e_ACTION}_LINK}
+  ...  css=[class*="UpvoteStatus"] button
+  ${t_actionType}=  Set Variable If  "${e_ACTION}"=="LIKES"
+  ...  LIKE  LIKES
+  ${t_text}=  Get Text  ${t_locator}
+  ${t_likeCount}=  Remove String  ${t_text}  ${t_actionType}
+  ${t_value}=  Convert To Integer  ${t_likeCount}
+  Set Suite Variable  ${s_ACTION}  ${e_ACTION}
+  Set Suite Variable  ${s_COUNT}   ${t_value}
+  Wait And Click Element  ${t_locator}
+
+User "${e_ACTION}" A Comment
+  ${t_locator}=  Set Variable  ${COMMMENT_DIV}:first
+  ${t_actionType}=  Set Variable If  "${e_ACTION}"=="LIKES"
+  ...  LIKES  LIKES
+  Wait Until Element Should Be Visible  ${t_locator} ${COMMENT_ACTION_CONTAINER}:eq(1)
+  ${t_text}=  Get Text  ${t_locator} ${COMMENT_ACTION_CONTAINER}:eq(1)
+  ${t_likeCount}=  Remove String  ${t_text}  ${t_actionType}
+  ${t_value}=  Convert To Integer  ${t_likeCount}
+  Set Suite Variable  ${s_ACTION}  ${e_ACTION}
+  Set Suite Variable  ${s_COUNT}   ${t_value}
+  Modify Element Attribute Via jQuery  ${GOVERNANCE_MENU}  display  none
+  Set Focus To Element  ${t_locator} ${LIKE_ICON}
+  Wait And Click Element  ${t_locator} ${LIKE_ICON}
+  Set Suite Variable  ${s_COMMENT_THREAD}  ${t_locator}
+
+#========#
+#  THEN  #
+#========#
+Proposoal Like Counter Should Be Correct In "${e_PAGE}" Page
+  ${t_counter}=  Compute Like Counter
+  ${t_locator}=  Set Variable If  "${e_PAGE}"=="DASHBOARD"
+  ...  ${PROPOSAL_CARD}:eq(0) ${DASHBOARD_${s_ACTION}_LINK}
+  ...  css=[class*="UpvoteStatus"] button
+  Wait Until ELement Should Contain  ${t_locator}  ${t_counter}
+
+Comment Like Counter Should Be Correct
+  [Arguments]  ${p_action}=${TRUE}
+  ${t_value}=  Run Keyword if  '${p_action}'=='${TRUE}'
+  ...  Compute Like Counter
+  ...  ELSE  Set Variable  ${s_LATEST_COUNTER}
+  ${t_strValue}=  Convert To String  ${t_value}
+  Wait Until Element Should Contain  ${s_COMMENT_THREAD} ${COMMENT_ACTION_CONTAINER}:eq(1)  ${t_strValue}
+
+#====================#
+#  INTERNAL KEYWORD  #
+#====================#
+Compute Like Counter
+  ${t_int}=  Convert To Integer  ${s_COUNT}
+  ${t_value}=  Run Keyword If  "${s_ACTION}"=="LIKES"
+  ...  Evaluate  ${t_int} + 1
+  ...  ELSE
+  ...  Evaluate  ${t_int} - 1
+  ${t_str}=  Convert To String  ${t_value}
+  Set Suite Variable  ${s_LATEST_COUNTER}  ${t_str}
+  [Return]  ${t_str}

--- a/src/resources/variables/comment_constants.robot
+++ b/src/resources/variables/comment_constants.robot
@@ -11,6 +11,8 @@ ${THREAD_FIELD}  ${THREAD_SECTION} > div > div > textarea
 ${THREAD_BUTTON}  ${THREAD_SECTION} ${POST_COMMENT_BTN}
 ${COMMMENT_DIV}  jquery=div[class*="ParentCommentItem"]
 ${COMMENT_POST}  div[class*="CommentPost"]
+${COMMENT_ACTION_CONTAINER}  [class*="ActionCommentButton"]
+${LIKE_ICON}  div[kind="like"]
 ${REPLY_ICON}  div[kind="reply"]
 ${COMMENT_REPLY}  section.comment-reply
 ${COMMENT_REPLY_POST}  div

--- a/src/resources/variables/like_unlike_constants.robot
+++ b/src/resources/variables/like_unlike_constants.robot
@@ -1,0 +1,3 @@
+*** Variables ***
+${DASHBOARD_LIKES_LINK}  [class*="ProposalFooter"] button
+${DASHBOARD_UNLIKES_LINK}  ${DASHBOARD_LIKES_LINK}

--- a/src/suite/functional/DaoCommentModuleTest.robot
+++ b/src/suite/functional/DaoCommentModuleTest.robot
@@ -19,7 +19,7 @@ Proposer Has Successfully Created A Proposal
 
 Proposer Has Successfully Posted Multiple Threads
   Given User Is In "GOVERNANCE" Page
-  When "proposer" Posts Multiple Thread On Created Proposal
+  When "proposer" Posts "11" Thread On Created Proposal
   Then All Thread Comments Should Be Visible
 
 Proposer Has Successfully Sorted Main Thread From Oldest
@@ -54,11 +54,3 @@ Proposer Has Successfully Deleted A Comment
   Given User Is In "PROPOSAL_VIEW" Page
   When "proposer" Deletes Main Thread "0"
   Then Main Thread "0" Messages Should Be Empty
-
-# Proposer Has Successfully Liked A Comment
-#   Given User Is In "PROPOSAL_VIEW" Page
-#   When "proposer" Likes Main Thread "1"
-#   Then Main Thread "1" Should Have Like
-#   When User Revisits Newly Created Proposal
-#   And "proposer" Sorts Main Thread From "Latest"
-#   Then Main Thread "1" Should Have Like

--- a/src/suite/functional/DaoLikeModuleTest.robot
+++ b/src/suite/functional/DaoLikeModuleTest.robot
@@ -1,0 +1,55 @@
+*** Settings ***
+Documentation  This suite will test like/unlike module for proposal and
+...  comments
+Force Tags    smoke    regression  disabled
+Default Tags    DaoLikeModuleTest
+Suite Teardown    Close All Browsers
+Resource  ../../resources/common/web_helper.robot
+Resource  ../../resources/keywords/governance_page.robot
+Resource  ../../resources/keywords/like_unlike_module.robot
+Resource  ../../resources/keywords/comment_module.robot
+
+*** Test Cases ***
+Proposer Has Successfully Created A Proposal
+  [Setup]  "proposer" Account Has Successfully Logged In To DigixDao Using "json"
+  Given User Is In "GOVERNANCE" Page
+  When "proposer" Creates A Governance Propsosal
+  Then User Should Be Redirected To "GOVERNANCE" Page
+  And Newly Created Proposal Should Be Visible On "Idea" Tab
+  And Proposal Status Should Be "IDEA"
+
+Proposer Has Successfully Liked A Proposal
+  Given User Is In "GOVERNANCE" Page
+  And Newly Created Proposal Should Be Visible On "All" Tab
+  When User "LIKES" Newly Created Proposal In "DASHBOARD" Page
+  Then Proposoal Like Counter Should Be Correct In "DASHBOARD" Page
+  When Go To Newly Created Proposal View Page
+  Then Proposoal Like Counter Should Be Correct In "PROPOSAL_VIEW" Page
+
+Proposer Has Successfully UnLiked A Proposal
+  Given User Is In "PROPOSAL_VIEW" Page
+  When User "UNLIKES" Newly Created Proposal In "PROPOSAL_VIEW" Page
+  Then Proposoal Like Counter Should Be Correct In "PROPOSAL_VIEW" Page
+  When Go Back To Dashboard Page
+  Then Newly Created Proposal Should Be Visible On "All" Tab
+  And Proposoal Like Counter Should Be Correct In "DASHBOARD" Page
+
+Proposer Has Successfully Liked A Comment
+  Given User Is In "GOVERNANCE" Page
+  When "proposer" Posts "1" Thread On Created Proposal
+  Then All Thread Comments Should Be Visible
+  When User "LIKES" A Comment
+  Then Comment Like Counter Should Be Correct
+  When Go Back To Dashboard Page
+  And Go To Newly Created Proposal View Page
+  Then Comment Like Counter Should Be Correct  NoAction
+
+Proposer Has Successfully Unliked A Comment
+  [Setup]  Go Back To Dashboard Page
+  Given User Is In "GOVERNANCE" Page
+  When Go To Newly Created Proposal View Page
+  And User "UNLIKES" A Comment
+  Then Comment Like Counter Should Be Correct
+  When Go Back To Dashboard Page
+  And Go To Newly Created Proposal View Page
+  Then Comment Like Counter Should Be Correct  NoAction


### PR DESCRIPTION
*** Test Case***
```
*** Test Cases ***
Proposer Has Successfully Created A Proposal
  [Setup]  "proposer" Account Has Successfully Logged In To DigixDao Using "json"
  Given User Is In "GOVERNANCE" Page
  When "proposer" Creates A Governance Propsosal
  Then User Should Be Redirected To "GOVERNANCE" Page
  And Newly Created Proposal Should Be Visible On "Idea" Tab
  And Proposal Status Should Be "IDEA"

Proposer Has Successfully Liked A Proposal
  Given User Is In "GOVERNANCE" Page
  And Newly Created Proposal Should Be Visible On "All" Tab
  When User "LIKES" Newly Created Proposal In "DASHBOARD" Page
  Then Proposoal Like Counter Should Be Correct In "DASHBOARD" Page
  When Go To Newly Created Proposal View Page
  Then Proposoal Like Counter Should Be Correct In "PROPOSAL_VIEW" Page

Proposer Has Successfully UnLiked A Proposal
  Given User Is In "PROPOSAL_VIEW" Page
  When User "UNLIKES" Newly Created Proposal In "PROPOSAL_VIEW" Page
  Then Proposoal Like Counter Should Be Correct In "PROPOSAL_VIEW" Page
  When Go Back To Dashboard Page
  Then Newly Created Proposal Should Be Visible On "All" Tab
  And Proposoal Like Counter Should Be Correct In "DASHBOARD" Page

Proposer Has Successfully Liked A Comment
  Given User Is In "GOVERNANCE" Page
  When "proposer" Posts "1" Thread On Created Proposal
  Then All Thread Comments Should Be Visible
  When User "LIKES" A Comment
  Then Comment Like Counter Should Be Correct
  When Go Back To Dashboard Page
  And Go To Newly Created Proposal View Page
  Then Comment Like Counter Should Be Correct  NoAction

Proposer Has Successfully Unliked A Comment
  [Setup]  Go Back To Dashboard Page
  Given User Is In "GOVERNANCE" Page
  When Go To Newly Created Proposal View Page
  And User "UNLIKES" A Comment
  Then Comment Like Counter Should Be Correct
  When Go Back To Dashboard Page
  And Go To Newly Created Proposal View Page
  Then Comment Like Counter Should Be Correct  NoAction
```