### PR TITLE
Created DaoSideNavMenuTest.robot

### DIFF
--- a/src/resources/keywords/governance_page.robot
+++ b/src/resources/keywords/governance_page.robot
@@ -87,6 +87,10 @@ User Submits Locked DGD
 #========#
 #  THEN  #
 #========#
+"${e_STATE}" SideNav Menu Items Should Be Visible
+  :FOR  ${locator}  IN  @{${e_STATE}_SIDENAV_LIST}
+  \  Wait Until Element Should Be Visible  ${locator}
+
 Proposal Details Should Be Correct On Proposal Details Page
   Go To Newly Created Proposal View Page
   Wait Until Element Contains  ${PROPOSAL_TITLE_DIV}  ${g_GENERIC_VALUE}
@@ -260,6 +264,17 @@ Compute Suite Total Funding
   ${t_total}=  Evaluate  ${s_REWARD_AMOUNT} + ${s_MILESTONE_AMOUNT}
   ${t_strFunding}=  Convert To String  ${t_total}
   Set Suite Variable  ${s_TOTAL_FUNDING}  ${t_strFunding}
+
+"${e_USER}" Submits "${e_WALLET_TYPE}" Wallet
+  "${e_USER}" Uploads "${e_WALLET_TYPE}" Wallet
+  User Submits Keystore Password
+  Wait Until Element Should Be Visible  ${MESSAGE_SIGNER_FORM}
+  User Submits Keystore Password  #sign message modal
+  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
+  Wait Until Element Should Be Visible  ${ADDRESS_INFO_SIDEBAR}
+  Click Element  ${CLOSE_ICON}
+  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
+
 #====================#
 #  SETUP / TEARDOWN  #
 #====================#
@@ -272,17 +287,10 @@ Compute Suite Total Funding
   Wait And Click Element  ${GET_STARTED_BTN}
 
 "${e_USER}" Account Has Successfully Logged In To DigixDao Using "${e_WALLET_TYPE}"
-   ${t_entry}=  Set Variable If  "${ENVIRONMENT}"=="KOVAN"
+  ${t_entry}=  Set Variable If  "${ENVIRONMENT}"=="KOVAN"
   ...  ${KOVAN_GOVERNANCE_URL_EXT}  ${GOVERNANCE_LOGIN_URL_EXT}
   Launch Digix Website  ${t_entry}  ${ENVIRONMENT}  ${e_USER}
-  "${e_USER}" Uploads "${e_WALLET_TYPE}" Wallet
-  User Submits Keystore Password
-  Wait Until Element Should Be Visible  ${MESSAGE_SIGNER_FORM}
-  User Submits Keystore Password  #sign message modal
-  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
-  Wait Until Element Should Be Visible  ${ADDRESS_INFO_SIDEBAR}
-  Click Element  ${CLOSE_ICON}
-  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
+  "${e_USER}" Submits "${e_WALLET_TYPE}" Wallet
 
 Upload Json Wallet Based On Environment
   [Arguments]  ${p_filename}  ${p_environment}=${ENVIRONMENT}
@@ -292,3 +300,8 @@ Upload Json Wallet Based On Environment
 Go Back To Dashboard Page
   Wait And Click Element  ${HOME_SIDE_MENU_ICON}
   Wait Until Element Should Be Visible  ${GOVERNANCE_FILTER_SECTION}
+
+"${e_USER}" Launch Governance Page
+  ${t_entry}=  Set Variable If  "${ENVIRONMENT}"=="KOVAN"
+  ...  ${KOVAN_GOVERNANCE_URL_EXT}  ${GOVERNANCE_LOGIN_URL_EXT}
+  Launch Digix Website  ${t_entry}  ${ENVIRONMENT}  ${e_USER}

--- a/src/resources/variables/governance_constants.robot
+++ b/src/resources/variables/governance_constants.robot
@@ -4,11 +4,16 @@ ${SALT_FILE_EXT}  _salt.json
 #side-menu
 ${SIDE_MENU_DIV}  css=ul[class*="MenuList"]
 ${HOME_SIDE_MENU_ICON}  css=div[kind="home"]
-${ACTIVITY_SIDE_MENU_ICON}  css=div[kind="activity"]
-# ${WALLET_SIDE_MENU_ICON}
-# ${PROFILE_SIDE_MENU_ICON}
-# ${HISTORY_SIDE_MENU_ICON}
-# ${HELP_SIDE_MENU_ICON}
+${WALLET_SIDE_MENU_ICON}  css=div[kind="wallet"]
+${PROFILE_SIDE_MENU_ICON}  css=div[kind="profile"]
+${HISTORY_SIDE_MENU_ICON}  css=div[kind="history"]
+${DAO_TOUR_SIDE_MENU_ICON}  css=div[kind="product"]
+@{LOGGED_OUT_SIDENAV_LIST}
+...  ${HOME_SIDE_MENU_ICON}  ${DAO_TOUR_SIDE_MENU_ICON}
+@{LOGGED_IN_SIDENAV_LIST}
+...  ${WALLET_SIDE_MENU_ICON}  ${PROFILE_SIDE_MENU_ICON}
+...  ${HISTORY_SIDE_MENU_ICON}  @{LOGGED_OUT_SIDENAV_LIST}
+
 #generic
 ${SNACK_BAR_DIV}  jquery=div[class*="SnackbarContainer"]
 ${ROUND_BTN}  button[class*="RoundBtn"]

--- a/src/suite/functional/DaoSideNavMenuTest.robot
+++ b/src/suite/functional/DaoSideNavMenuTest.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Documentation  This suite will test assert side nav menu list
+...  when a user is in logged in and logged out state. (DGDG-284)
+Force Tags  regression
+Default Tags    DaoSideNavMenuTest
+Suite Setup  "Guest" Launch Governance Page
+Suite Teardown    Close All Browsers
+Resource  ../../resources/common/web_helper.robot
+Resource  ../../resources/keywords/governance_page.robot
+
+*** Test Cases ***
+Guest User Has Successfully Visited Governance Page
+  Given User Is In "GOVERNANCE" Page
+  Then "LOGGED_OUT" SideNav Menu Items Should Be Visible
+
+User Has Sucessfully Logged In To Governance Page
+  Given User Is In "GOVERNANCE" Page
+  When "participant" Submits "json" Wallet
+  Then "LOGGED_IN" SideNav Menu Items Should Be Visible


### PR DESCRIPTION
counter part feature: DGDG-284
tracker: DT-45

Coverage:
- assert Home and Dao Tour SideNav Menu List when User State is Logged Out
- assert Home, Wallet, Profile, Transaction History and Dao Tour SideNav Menu List when User State is Logged In

*** test Cases ***
```
Guest User Has Successfully Visited Governance Page
  Given User Is In "GOVERNANCE" Page
  Then "LOGGED_OUT" SideNav Menu Items Should Be Visible

User Has Sucessfully Logged In To Governance Page
  Given User Is In "GOVERNANCE" Page
  When "participant" Submits "json" Wallet
  Then "LOGGED_IN" SideNav Menu Items Should Be Visible
```