### PR TITLE
Created DaoProfileOverviewTest

### DIFF
--- a/src/resources/keywords/governance_page.robot
+++ b/src/resources/keywords/governance_page.robot
@@ -2,9 +2,25 @@
 Resource    ../variables/governance_constants.robot
 
 *** Keywords ***
+#=========#
+#  GIVEN  #
+#=========#
+Pull Profile Stats Data
+  Wait Until Element Should Be Visible  ${DASHBOARD_STATS_DIV}
+  ${t_qp}=  Get Text  ${STAT_QUARTER_POINT}
+  ${t_rp}=  Get Text  ${STAT_REPUTATION_POINT}
+  ${t_sp}=  Get Text  ${STAT_MYSTAKE_POINT}
+  Set Suite Variable  ${s_QUARTER_PTS}  ${t_qp}
+  Set Suite Variable  ${s_REPUTATION_PTS}  ${t_rp}
+  Set Suite Variable  ${s_STAKE_PTS}  ${t_sp}
+
 #========#
 #  WHEN  #
 #========#
+User Goes To "${e_SIDEMENU}" View Page
+  Wait Until Element Should Be Visible  ${SIDE_MENU_DIV}
+  Wait And Click Element  ${${e_SIDEMENU}_SIDE_MENU_ICON}
+
 User Submits Locked DGD
   [Arguments]  ${p_amount}=${LOCKED_DGD_AMOUNT}
   Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}

--- a/src/resources/keywords/profile_view_page.robot
+++ b/src/resources/keywords/profile_view_page.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Resource    ../variables/profile_view_constants.robot
+
+*** Keywords ***
+#========#
+#  THEN  #
+#========#
+Assert User Profile Values Are Correct
+  Wait Until Element Should be Visible  ${PROFILE_REWARD_DIV}
+  Wait Until ELement Should Contain  ${PROFILE_QUARTER_AMOUNT}  ${s_QUARTER_PTS}
+  Wait Until ELement Should Contain  ${PROFILE_REPUTATION_AMOUNT}  ${s_REPUTATION_PTS}
+  Wait Until ELement Should Contain  ${PROFILE_STAKE_AMOUNT}  ${s_STAKE_PTS}
+
+Gain Moderator Status Card Should Be Visible Based On Role
+  Wait Until Element Should Be Visible  ${PROFILE_ROLE_DIV}
+  ${t_role}=  Get Text  ${PROFILE_ROLE_DIV}
+  Run Keyword If  "${t_role}"=="Moderator"
+  ...  Wait Until Element Should Not Be Visible  ${PROFILE_MODERATOR_CARD}
+  ...  ELSE  Moderator Status Card Is Visible And Values Are Correct
+
+Moderator Status Card Is Visible And Values Are Correct
+  Wait Until Element Should Be Visible  ${PROFILE_MODERATOR_CARD}
+  ${t_strRep}=  Compute Remaining Value  REPUTATION
+  ${t_strStake}=  Compute Remaining Value  STAKE
+  ${t_eval}=  Evaluate  ${t_strRep} > 0 or ${t_strStake} > 0
+  Run Keyword If  ${t_eval}==${TRUE}  Run Keywords
+  ...  Wait Until ELement Should Contain  ${PROFILE_REMAINING_REPUTATION}  ${t_strRep}
+  ...  AND  Wait Until ELement Should Contain  ${PROFILE_REMAINING_STAKE}  ${t_strStake}
+
+Compute Remaining Value
+  [Arguments]  ${p_type}
+  ${t_result}=  Run Keyword And Return Status
+  ...  Should Contain  ${s_${p_type}_PTS}  .
+  ${t_function}=  Set Variable If   ${t_result}
+  ...  Convert To Number  Convert To Integer
+  ${t_test}=  Run Keyword  ${t_function}  ${s_${p_type}_PTS}
+  ${t_remaining}=  Evaluate  ${${ENVIRONMENT}_MIN_${p_type}_PTS} - ${t_test}
+  ${t_value}=  Set Variable If  ${t_remaining} >= 0
+  ...  ${t_remaining}  0
+  ${t_strValue}=  Convert To String  ${t_value}
+  [Return]  ${t_strValue}

--- a/src/resources/variables/governance_constants.robot
+++ b/src/resources/variables/governance_constants.robot
@@ -14,6 +14,12 @@ ${DAO_TOUR_SIDE_MENU_ICON}  css=div[kind="product"]
 ...  ${WALLET_SIDE_MENU_ICON}  ${PROFILE_SIDE_MENU_ICON}
 ...  ${HISTORY_SIDE_MENU_ICON}  @{LOGGED_OUT_SIDENAV_LIST}
 
+# user profile stats
+${DASHBOARD_STATS_DIV}  jquery=[class*="timeline"] + [class*="Container"]
+${STAT_QUARTER_POINT}  ${DASHBOARD_STATS_DIV} [class*="Point"]:eq(0) span
+${STAT_REPUTATION_POINT}  ${DASHBOARD_STATS_DIV} [class*="Point"]:eq(1) span
+${STAT_MYSTAKE_POINT}  ${DASHBOARD_STATS_DIV} [class*="Point"]:eq(2) span
+
 #generic
 ${SNACK_BAR_DIV}  jquery=div[class*="SnackbarContainer"]
 ${ROUND_BTN}  button[class*="RoundBtn"]

--- a/src/resources/variables/profile_view_constants.robot
+++ b/src/resources/variables/profile_view_constants.robot
@@ -1,0 +1,15 @@
+*** Variables ***
+${PROFILE_ROLE_DIV}           css=[data-digix="Profile-Status"]
+${PROFILE_REWARD_DIV}         jquery=[class*="RewardSummary"]
+${PROFILE_QUARTER_AMOUNT}     css=[data-digix="Profile-QuarterPoints"]
+${PROFILE_REPUTATION_AMOUNT}  css=[data-digix="Profile-ReputationPoints"]
+${PROFILE_STAKE_AMOUNT}       css=[data-digix="Profile-Stake"]
+${PROFILE_MODERATOR_CARD}     css=[class*="Moderation"]
+${PROFILE_REMAINING_REPUTATION}  css=[data-digix="Profile-ModerationRequirements-Reputation"]
+${PROFILE_REMAINING_STAKE}    css=[data-digix="Profile-ModerationRequirements-Stake"]
+
+#constants
+${LOCAL_MIN_STAKE_PTS}    100
+${KOVAN_MIN_STAKE_PTS}    1000
+${LOCAL_MIN_REPUTATION_PTS}  1
+${KOVAN_MIN_REPUTATION_PTS}  ${EMPTY}

--- a/src/suite/functional/DaoProfileOverviewTest.robot
+++ b/src/suite/functional/DaoProfileOverviewTest.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Documentation  This suite will test asserting values on Profile Overview are
+...  correct and validate components are showing correcly based on user role
+Force Tags  regression
+Default Tags    DaoProfileOverviewTest
+Suite Teardown    Close All Browsers
+Resource  ../../resources/common/web_helper.robot
+Resource  ../../resources/keywords/governance_page.robot
+Resource  ../../resources/keywords/profile_view_page.robot
+
+*** Test Cases ***
+Participant Has Successfully Validated Stats On Profile View Page
+  [Setup]  "participant" Account Has Successfully Logged In To DigixDao Using "json"
+  Given User Is In "GOVERNANCE" Page
+  And Pull Profile Stats Data
+  When User Goes To "Profile" View Page
+  Then Assert User Profile Values Are Correct
+  And Gain Moderator Status Card Should Be Visible Based On Role
+
+Moderator Has Successfully Validated Stats On Profile View Page
+  [Setup]  "moderator" Account Has Successfully Logged In To DigixDao Using "json"
+  Given User Is In "GOVERNANCE" Page
+  And Pull Profile Stats Data
+  When User Goes To "Profile" View Page
+  Then Assert User Profile Values Are Correct
+  And Gain Moderator Status Card Should Be Visible Based On Role


### PR DESCRIPTION
feature: DGDG-30
tracker: DT-46

Coverage:
    - if wallet is a participant, assert user stats values are correct on profiile view page AND gain moderator status card is visible
    - if wallet is a moderator, assert user stats values are correct on profile view page AND gain moderator status card should not be visible
    - if gain moderator status card is visible THEN compute remaining reputation and stake values AND show it on the card

*** test Cases ***
```
Participant Has Successfully Validated Stats On Profile View Page
  [Setup]  "participant" Account Has Successfully Logged In To DigixDao Using "json"
  Given User Is In "GOVERNANCE" Page
  And Pull Profile Stats Data
  When User Goes To "Profile" View Page
  Then Assert User Profile Values Are Correct
  And Gain Moderator Status Card Should Be Visible Based On Role

Moderator Has Successfully Validated Stats On Profile View Page
  [Setup]  "moderator" Account Has Successfully Logged In To DigixDao Using "json"
  Given User Is In "GOVERNANCE" Page
  And Pull Profile Stats Data
  When User Goes To "Profile" View Page
  Then Assert User Profile Values Are Correct
  And Gain Moderator Status Card Should Be Visible Based On Role
```