### PR TITLE
refactor governance_page.robot file and fix intermittent issues across test suites

### DIFF
--- a/src/resources/keywords/comment_module.robot
+++ b/src/resources/keywords/comment_module.robot
@@ -56,14 +56,12 @@ Resource    ../variables/comment_constants.robot
   ${t_text}=  Get Text  ${COMMMENT_DIV}:eq(0) ${COMMENT_POST}
   Set Suite Variable  ${s_THREAD_ONE_VALUE}  ${t_text}
   Select From List By Label  ${SORTING_DD}  ${e_SORTING}
+  Sleep  3 seconds
+  Wait Until Element Should Be Visible  ${COMMMENT_DIV}:eq(0)
 
 User Shows All Main Thread Comments
-  ${t_default}=  Get Selenium Speed
-  Set Selenium Speed  0.2 s
-  Wait Until ELement Should Be Visible  ${THREAD_SECTION} > button
-  Set Focus To Element  ${THREAD_SECTION} > button
-  Click Element  ${THREAD_SECTION} > button
-  Set Selenium Speed  ${t_default}
+  Wait Until Element Should Be Visible  ${THREAD_SECTION}
+  Wait And Click Element  ${THREAD_SECTION} > button
 
 User Shows All "${e_COMMENT_TYPE}" Comments
   ${t_BUTTON}=  Set Variable  ${COMMMENT_DIV}:eq(${s_${e_COMMENT_TYPE}_NUMBER}) button[class*="TextBtn"]:last
@@ -86,12 +84,14 @@ User Shows All "${e_COMMENT_TYPE}" Comments
 #  THEN  #
 #========#
 All Thread Comments Should Be Visible
+  Wait Until Element Should Be Visible  ${COMMMENT_DIV}
   :FOR  ${index}  ${value}  IN ENUMERATE  @{g_THREAD_VALUES}
   \  ${t_div}=  Set Variable  ${COMMMENT_DIV}:eq(${index}) ${COMMENT_POST}
   \  Wait Until ELement Should Contain  ${t_div}  ${value}
 
 Main Thread Should Be Sorted
-  Wait Until ELement Should Contain  ${COMMMENT_DIV}:eq(0)  ${s_THREAD_ONE_VALUE}
+  Wait Until Element Should Be Visible  ${COMMMENT_DIV}:eq(0)
+  Wait Until ELement Should Not Contain  ${COMMMENT_DIV}:eq(0)  ${s_THREAD_ONE_VALUE}
 
 All Comments Should Be Visible
   ${t_thread_div}=  Set Variable  ${COMMMENT_DIV}:eq(${s_${s_TYPE}_NUMBER})

--- a/src/resources/keywords/create_edit_proposal_page.robot
+++ b/src/resources/keywords/create_edit_proposal_page.robot
@@ -1,0 +1,84 @@
+*** Settings ***
+Resource    ../variables/governance_constants.robot
+
+*** Variables ***
+${GOVERNANCE_CREATE_BTN}  css=a[href="#/proposals/create"] button
+# create proposal fields
+${PROPOSAL_TAB_PANEL}  jquery=div[class*="TabPanel"]
+${PROPOSAL_MENU}  ${PROPOSAL_TAB_PANEL} +  [class*="Header"] > div:eq(1)
+${PROPOSAL_MENU_PREVIEW_BTN}  ${PROPOSAL_MENU} button:eq(0)
+${PROPOSAL_MENU_PREVIOUS_BTN}  ${PROPOSAL_MENU} button:eq(1)
+${PROPOSAL_MENU_NEXT_BTN}  ${PROPOSAL_MENU} button:eq(2)
+${PROJECT_TITLE_FIELD}  css=input[id="title"]
+${PROJECT_DESC_FIELD}  css=textarea[id="description"]
+${PROJECT_INFO_FIELD}  css=#details .ql-editor
+${UPLOAD_IMAGE_BTN}  css=[class*="UploadButton"]
+${IMAGE_UPLOAD_BTN}  css=input[id="image-upload"][type="file"]
+${REWARD_FIELD}  css=input[id="finalReward"]
+${NUM_OF_MILESTONE_FIELD}  css=select[id="noOfMilestones"]
+${MILESTONE_FORM}  jquery=div[class*="CreateMilestone"]
+${MILESTONE_FIELD}  ${MILESTONE_FORM} input
+${MILESTONE_DESC_FIELD}  ${MILESTONE_FORM} textarea
+${CREATE_NOW_BTN}  ${PROPOSAL_MENU_NEXT_BTN}
+${PROPOSAL_SUBMIT_BTN}  jquery=div[class*="ContentWrapper"] button:eq(1)
+*** Keywords ***
+#========#
+#  WHEN  #
+#========#
+"${e_USER}" Creates A Governance Propsosal
+  Wait Until Element Should Be Visible  ${ADDRESS_LABEL}
+  Wait And Click Element  ${GOVERNANCE_CREATE_BTN}
+  User Submit Proposal Details
+
+"${e_USER}" Edits Newly Created Proposal Details
+  Wait And Click Element  ${PROJECT_SUMMARY} ${ROUND_BTN}:last
+  User Submit Proposal Details  3  4  edit
+
+User Submit Proposal Details
+  [Arguments]  ${p_reward}=${MILESTONE_REWARD_AMOUNT}  ${p_milestone}=${MILESTONE_AMOUNT}  ${p_type}=Create
+  ${t_time}=  Get Time  epoch
+  ${t_strValue}=  Convert To String  ${t_time}
+  ${t_value}=  Set Variable If  "${p_type}"=="Create"
+  ...  ${t_strValue}  ${t_strValue} - edit
+  Log To Console  ProjectName:${t_strValue}
+  # overview
+  Wait Until Element Should Be Visible  ${PROJECT_TITLE_FIELD}
+  Input Text  ${PROJECT_TITLE_FIELD}  ${t_value}
+  Input Text  ${PROJECT_DESC_FIELD}  ${t_value}
+  Click Element  ${PROPOSAL_MENU_NEXT_BTN}
+  #project detail
+  Wait Until Element Should Be Visible  ${PROJECT_INFO_FIELD}
+  Clear Element Text  ${PROJECT_INFO_FIELD}
+  Press Key  ${PROJECT_INFO_FIELD}  ${t_value}
+  Click Element  ${PROPOSAL_MENU_NEXT_BTN}
+  #multimedia
+  Wait Until Element Should Be Visible  ${UPLOAD_IMAGE_BTN}
+  Modify Element Attribute Via jQuery  ${IMAGE_UPLOAD_BTN}  display  block
+  Upload TestData Image  image
+  Click Element  ${PROPOSAL_MENU_NEXT_BTN}
+  #milestone
+  Wait Until Element Should Be Visible  ${MILESTONE_FORM}
+  Input Text  ${REWARD_FIELD}  ${p_reward}
+  Select From List By Label  ${NUM_OF_MILESTONE_FIELD}  ${NUMBER_OF_MILESTONE}
+  Input Text  ${MILESTONE_FIELD}:eq(0)  ${p_milestone}
+  Input Text  ${MILESTONE_DESC_FIELD}:eq(0)  ${t_value}
+  Set Suite Variable  ${s_REWARD_AMOUNT}  ${p_reward}
+  Set Suite Variable  ${s_MILESTONE_AMOUNT}  ${p_milestone}
+  Compute Suite Total Funding
+  Click Element  ${CREATE_NOW_BTN}
+  #prevew
+  Wait And Click Element  ${PROPOSAL_SUBMIT_BTN}
+  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
+  User Submits Keystore Password  #transaction modal
+  Set Global Variable  ${g_GENERIC_VALUE}  ${t_value}
+  Run Keyword If  '${ENVIRONMENT}'=='KOVAN'  Run Keywords
+  ...  Log To Console  sleep the test due to it runs on ${ENVIRONMENT} for 60 seconds
+  ...  AND  Sleep  60 seconds
+
+#=====================#
+#  INTERNAL KEYWORDS  #
+#=====================#
+Compute Suite Total Funding
+  ${t_total}=  Evaluate  ${s_REWARD_AMOUNT} + ${s_MILESTONE_AMOUNT}
+  ${t_strFunding}=  Convert To String  ${t_total}
+  Set Suite Variable  ${s_TOTAL_FUNDING}  ${t_strFunding}

--- a/src/resources/keywords/governance_page.robot
+++ b/src/resources/keywords/governance_page.robot
@@ -1,6 +1,7 @@
 *** Settings ***
+Resource    create_edit_proposal_page.robot
+Resource    proposal_view_page.robot
 Resource    ../variables/governance_constants.robot
-
 *** Keywords ***
 #=========#
 #  GIVEN  #
@@ -29,79 +30,39 @@ User Submits Locked Stake
   Wait And Click Element  ${LOCK_WITH_AMOUNT_BTN}
   User Submits Keystore Password
 
-User Submits Locked DGD
-  [Arguments]  ${p_amount}=${LOCKED_DGD_AMOUNT}
-  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
-  Wait Until Element Should Be Visible  ${ADDRESS_INFO_SIDEBAR}
-  Wait And Click Element  ${LOCK_DGD_BTN}
-  User Submits Locked Stake  ${p_amount}
-
-"${e_USER_TYPE}" Submits "${e_WALLET_TYPE}" Wallet To Locked DGD
-  "${e_USER_TYPE}" Uploads "${e_WALLET_TYPE}" Wallet
-  User Submits Keystore Password
+"${e_USER}" Submits "${e_WALLET_TYPE}" Wallet
+  # uploading
+  Load JQuery Tool
+  Wait And Click Element  ${LOAD_WALLET_BTN}
+  Wait And Click Element  ${LOAD_WALLET_SIDEBAR_BUTTON}
+  Wait And Click Element  ${LOAD_WALLET_SIDEBAR_BUTTON} ${WALLET_${e_WALLET_TYPE}_BTN}
+  Wait Until Element Should Be Visible  ${IMPORT_KEYSTORE_ICON} svg
+  Run Keyword If  "${e_WALLET_TYPE}"=="json"
+  ...  Upload Json Wallet Based On Environment  ${e_USER}
+  User Submits Keystore Password  #validate wallet password
   Wait Until Element Should Be Visible  ${MESSAGE_SIGNER_FORM}
   User Submits Keystore Password  #sign message modal
-  User Submits Locked DGD
+  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
+  Wait Until Element Should Be Visible  ${ADDRESS_INFO_SIDEBAR}
+  Click Element  ${CLOSE_ICON}
+  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
 
-"${e_USER}" Creates A Governance Propsosal
-  Wait Until Element Should Be Visible  ${ADDRESS_LABEL}
-  Wait And Click Element  ${GOVERNANCE_CREATE_BTN}
-  Submit Proposal Details
+Go Back To Dashboard Page
+  Wait And Click Element  ${HOME_SIDE_MENU_ICON}
+  Wait Until Element Should Be Visible  ${GOVERNANCE_FILTER_SECTION}
 
-"${e_USER}" Edits Newly Created Proposal Details
+Go To Newly Created Proposal View Page
+  Get Proposal Card Index
+  Hide SnackBar
+  Hide Governance Header Menu
+  Wait And Click Element  ${s_PROPOSAL_INDEX}
+
+Visit Newly Created Proposal And Click "${e_ACTION}" Action
+  Go To Newly Created Proposal View Page
   Wait And Click Element  ${PROJECT_SUMMARY} ${ROUND_BTN}:last
-  Submit Proposal Details  3  4  edit
-
-"${e_USER}" Approves Newly Drafted Proposal
-  Proposal Status Should Be "DRAFT"
-  Visit Newly Created Proposal And Click "Approve" Action
-  Get Remaining Time To Execute Next Step
-  Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
-  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(0)
-  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(2)
-  User Submits Keystore Password  #transaction modal
-
-"${e_USER}" Votes "${e_RESPONSE}" On Proposal
-  Newly Created Proposal Should Be Visible On "All" Tab
-  Force Element Via jQuery  ${HELP_LAUNCHER}  hide
-  Visit Newly Created Proposal And Click "Vote" Action
-  Get Remaining Time To Execute Next Step
-  Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
-  Run Keyword If  "${e_RESPONSE}"=="Yes"
-  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(0)  #Yes vote button
-  ...  ELSE IF  "${e_RESPONSE}"=="No"
-  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(1)  #No vote button
-  ${t_salt}=  Get Element Attribute  ${GOVERNANCE_SIDE_PANEL} a:eq(0)  download
-  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} a:eq(0)  #Download Json File button
-  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(2)  #confirm commit button
-  Replace Salt File According To User Role  ${t_salt}  ${e_USER}
-  User Submits Keystore Password
-
-"${e_USER}" Reveals Vote Via Salt File
-  Newly Created Proposal Should Be Visible On "All" Tab
-  Visit Newly Created Proposal And Click "Reveal" Action
-  Get Remaining Time To Execute Next Step
-  "Upload" "${e_USER}" Salt File
-  Wait Until Element Should Be Visible  ${NOTE_CONTAINER}
-  Wait And Click Element  ${GOVERNANCE_SIDENAR_DIV} ${ROUND_BTN}
-  "Remove" "${e_USER}" Salt File
-  User Submits Keystore Password  #transaction modal
-
-"${e_USER}" Uploads Modified Salt File
-  ${t_path}=  Normalize Path  ~/Downloads/
-  ${t_content}=  Load Json From File  ${t_path}/${e_USER}${SALT_FILE_EXT}
-  ${t_vote}=  Get Value From Json  ${t_content}  vote
-  ${t_invert}=  Set Variable If  "${t_vote}"=="${true}"  false  true
-  ${t_new}=  Update Value To Json  ${t_content}  vote  ${t_invert}
-  ${t_write}=  Convert JSON To String  ${t_new}
-  Append To File  ${t_path}/${e_USER}_modified${SALT_FILE_EXT}  ${t_write}  encoding=UTF-8
-  ${t_user}=  Set Variable  ${e_USER}_modified
-  "${t_user}" Reveals Vote Via Salt File
-
-"${e_USER}" "${e_ACTION}" On Newly Created Proposal
-  Newly Created Proposal Should Be Visible On "All" Tab
-  Visit Newly Created Proposal And Click "${e_ACTION}" Action
-  User Submits Keystore Password  #transaction modal
+  # Assign ID For Interaction Buttons
+  # ${t_button}=  Return Action Button Names On Proposal  ${e_ACTION}
+  # Wait And Click Element  ${t_button}
 
 #========#
 #  THEN  #
@@ -110,217 +71,89 @@ User Submits Locked DGD
   :FOR  ${locator}  IN  @{${e_STATE}_SIDENAV_LIST}
   \  Wait Until Element Should Be Visible  ${locator}
 
-Proposal Details Should Be Correct On Proposal Details Page
-  Go To Newly Created Proposal View Page
-  Wait Until Element Contains  ${PROPOSAL_TITLE_DIV}  ${g_GENERIC_VALUE}
-  Wait And Click Element  ${PROPOSAL_MILESTONE_ARROW_ICON}
-  Wait Until Element Contains  ${PROPOSAL_SHORT_DESC_DIV}  ${g_GENERIC_VALUE}
-  Wait Until Element Contains  ${PROPOSAL_DESC_DIV}  ${g_GENERIC_VALUE}
-  Wait Until Element Contains  ${PROPOSAL_MS_DESC_DIV}  ${g_GENERIC_VALUE}
-  Wait Until Element Contains  ${PROPOSAL_MS_AMOUNT_DIV}  ${s_MILESTONE_AMOUNT}
-  Wait Until Element Contains  ${PROPOSAL_REWARD_DIV}  ${s_REWARD_AMOUNT}
-  Wait Until Element Contains  ${PROPOSAL_FUNDING_DIV}  ${s_TOTAL_FUNDING}
-
-User Should Be Able To Get Started On Governance
-  Wait Until Element Should Be Visible  ${CONGRATULATION_BANNER}
-  Wait Until Element Should Be Visible  ${GET_STARTED_BTN}
-
 Newly Created Proposal Should Be Visible On "${e_TAB}" Tab
-  Update Cards On "${e_TAB}" Tab
+  Switch "${e_TAB}" Tab To Update Content
   ${t_speed}=  Get Selenium Speed
   Run Keyword If  "${ENVIRONMENT}"=="KOVAN"
   ...  Set Selenium Speed  0.5 s
   Repeat Until Newly Created Project Is On "${e_TAB}" Tab
   Set Selenium Speed  ${t_speed}
 
-Repeat Until Newly Created Project Is On "${e_TAB}" Tab
-  Wait Until Element Should Be Visible  ${PROPOSAL_CARD}:eq(0) h2
-  :FOR  ${index}  IN RANGE  0  5
-  \  ${t_status}=  Run Keyword And Return Status
-  ...  Wait Until Element Contains  ${PROPOSAL_CARD}:eq(0) h2  ${g_GENERIC_VALUE}  timeout= 5 seconds
-  \  Run Keyword If  ${t_status}
-  ...  Exit For Loop
-  ...  ELSE  Update Cards On "${e_TAB}" Tab
-
-User Should Be Able To Participate On Proposal
-  Newly Created Proposal Should Be Visible On "All" Tab
-  # Wait Until Element Is Enabled  ${PROPOSAL_CARD}:eq(0) ${PARTICIPATE_BTN}
-
 Proposal Status Should Be "${e_STATUS}"
   Newly Created Proposal Should Be Visible On "All" Tab
   Run Keyword If  '${ENVIRONMENT}'!='KOVAN'  #temporary
   ...  Wait Until ELement Should Contain  ${PROPOSAL_CARD}:eq(0) ${PROPOSAL_STATUS_BTN}  ${e_STATUS}
 
-Vote Count Should Increase
-  Newly Created Proposal Should Be Visible On "All" Tab
-  # Wait And Click Element  ${PROPOSAL_CARD}:eq(0) ${VIEW_PROJECT_LINK}
-
 Snackbox Should Contain "${e_MESSAGE}"
-  # Wait Until Element Is Visible  ${SNACK_BAR_DIV}  timeout=${TIMEOUT_SEC}
   Wait Until ELement Should Contain  ${SNACK_BAR_DIV}  ${e_MESSAGE}
+  Modify Element Attribute Via jQuery  ${SNACK_BAR_DIV}  display  none
 
 #====================#
 #  INTERNAL KEYWORD  #
 #====================#
-Submit Proposal Details
-  [Arguments]  ${p_reward}=${MILESTONE_REWARD_AMOUNT}  ${p_milestone}=${MILESTONE_AMOUNT}  ${p_type}=Create
-  ${t_time}=  Get Time  epoch
-  ${t_strValue}=  Convert To String  ${t_time}
-  ${t_value}=  Set Variable If  "${p_type}"=="Create"
-  ...  ${t_strValue}  ${t_strValue} - edit
-  Log To Console  ProjectName:${t_strValue}
-  # overview
-  Wait Until Element Should Be Visible  ${PROJECT_TITLE_FIELD}
-  Input Text  ${PROJECT_TITLE_FIELD}  ${t_value}
-  Input Text  ${PROJECT_DESC_FIELD}  ${t_value}
-  Click Element  ${PROPOSAL_MENU_NEXT_BTN}
-  #project detail
-  Wait Until Element Should Be Visible  ${PROJECT_INFO_FIELD}
-  Clear Element Text  ${PROJECT_INFO_FIELD}
-  Press Key  ${PROJECT_INFO_FIELD}  ${t_value}
-  Click Element  ${PROPOSAL_MENU_NEXT_BTN}
-  #multimedia
-  Wait Until Element Should Be Visible  ${UPLOAD_IMAGE_BTN}
-  Modify Element Attribute Via jQuery  ${IMAGE_UPLOAD_BTN}  display  block
-  Upload TestData Image  image
-  Click Element  ${PROPOSAL_MENU_NEXT_BTN}
-  #milestone
-  Wait Until Element Should Be Visible  ${MILESTONE_FORM}
-  Input Text  ${REWARD_FIELD}  ${p_reward}
-  Select From List By Label  ${NUM_OF_MILESTONE_FIELD}  ${NUMBER_OF_MILESTONE}
-  Input Text  ${MILESTONE_FIELD}:eq(0)  ${p_milestone}
-  Input Text  ${MILESTONE_DESC_FIELD}:eq(0)  ${t_value}
-  Set Suite Variable  ${s_REWARD_AMOUNT}  ${p_reward}
-  Set Suite Variable  ${s_MILESTONE_AMOUNT}  ${p_milestone}
-  Compute Suite Total Funding
-  Click Element  ${CREATE_NOW_BTN}
-  #prevew
-  Wait And Click Element  ${PROPOSAL_SUBMIT_BTN}
-  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
-  User Submits Keystore Password  #transaction modal
-  Set Global Variable  ${g_GENERIC_VALUE}  ${t_value}
-  Run Keyword If  '${ENVIRONMENT}'=='KOVAN'  Run Keywords
-  ...  Log To Console  sleep the test due to it runs on ${ENVIRONMENT} for 60 seconds
-  ...  AND  Sleep  60 seconds
-
-Return Action Button Names On Proposal
-  [Arguments]  ${p_action}
-  ${t_dict}=  Create Dictionary
-  ...  Endorses Proposal=ENDORSE
-  ...  Finalizes Proposal=FINALIZE
-  ...  Approve=APPROVE
-  ...  Claims Approved Proposal=
-  ..   Vote=VOTE
-  ...  Reveal=REVEAL
-  ...  Claims Voting Result=
-  ...  Claims Proposal Funding=
-  ..,  Sets Proposal To Complete=
-  ${t_value}=  Get From Dictionary  ${t_dict}  ${p_action}
-  [Return]  css=#${t_value}
-
-User Submits Keystore Password
-  Wait Until Element Should Be Visible  ${IMPORT_PASSWORD_FIELD}
-  Input Text  ${IMPORT_PASSWORD_FIELD}  ${${ENVIRONMENT}_DAO__WALLET_PW}
-  Wait And Click Element  ${UNLOCK_WALLET_BTN}
-
-Update Cards On "${e_TAB}" Tab
-  Wait Until Element Should Be Visible  ${GOVERNANCE_FILTER_SECTION}
-  Modify Element Attribute Via jQuery  ${GOVERNANCE_MENU}  display  none
-  Wait And Click Element  ${ARCHIVED_TAB}
-  Wait And Click Element  ${${e_TAB}_TAB}
-
-Replace Salt File According To User Role
-  [Arguments]  ${p_filename}  ${p_role}
-  ${t_path}=  Normalize Path  ~/Downloads/
-  Wait Until Created  ${t_path}/${p_filename}  timeout=${g_TIMEOUT_SEC}
-  Move File  ${t_path}/${p_filename}  ${t_path}/${p_role}${SALT_FILE_EXT}
-
-Hide SnackBar
-  ${t_bar}=  Get Matching Locator Count  ${SNACK_BAR_DIV}
-  :For  ${index}  IN RANGE  0  ${t_bar}
-  \  Force Element Via jQuery  ${SNACK_BAR_DIV}:eq(${index})  hide
-
-Get Remaining Time To Execute Next Step
-  Wait Until Element Should Be Visible  ${TIMER_DIV}
-  ${t_text}=  Get Text  ${TIMER_DIV}
-  Set Global Variable  ${g_TIMER}  ${t_text}
-
-Go To Newly Created Proposal View Page
-  Wait Until Element Should Be Visible  ${PROPOSAL_CARD}:eq(0) h2
-  Wait Until ELement Should Contain  ${PROPOSAL_CARD}:eq(0) h2  ${g_GENERIC_VALUE}
-  Hide SnackBar
-  Modify Element Attribute Via jQuery  ${GOVERNANCE_MENU}  display  none
-  Wait And Click Element  ${PROPOSAL_CARD}:eq(0) ${VIEW_PROJECT_LINK}
-
-Visit Newly Created Proposal And Click "${e_ACTION}" Action
-  Go To Newly Created Proposal View Page
-  Wait Until Element Should Be Visible  ${PROJECT_SUMMARY}
-  Wait And Click Element  ${PROJECT_SUMMARY} ${ROUND_BTN}:last
-  # ${t_buttons}=  Get WebElements  ${PROJECT_SUMMARY} ${ROUND_BTN}
-  # :FOR  ${locator}  IN  @{t_buttons}
-  # \  ${t_text}=  Get Text  ${locator}
-  # \  Assign Id To Element  ${locator}  ${t_text}
-  # ${t_button}=  Return Action Button Names On Proposal  ${e_ACTION}
-  # Click Element  ${t_button}
-
-"${e_ACTION}" "${e_USER}" Salt File
-  ${t_file}=  Normalize Path  ~/Downloads/${e_USER}${SALT_FILE_EXT}
-  Run Keyword If  "${e_ACTION}"=="Upload"  Run Keywords
-  ...  Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
-  ...  AND  Choose File  ${SALT_JSON_UPLOAD_BTN}  ${t_file}
-  ...  ELSE  Remove File  ${t_file}
-
-"${e_USER}" Uploads "${e_WALLET_TYPE}" Wallet
-  Load JQuery Tool
-  Wait And Click Element  ${LOAD_WALLET_BTN}
-  Wait And Click Element  ${LOAD_WALLET_SIDEBAR_BUTTON}
-  Wait And Click Element  ${LOAD_WALLET_SIDEBAR_BUTTON} ${WALLET_${e_WALLET_TYPE}_BTN}
-  Wait Until Element Should Be Visible  ${IMPORT_KEYSTORE_ICON} svg
-  Run Keyword If  "${e_WALLET_TYPE}"=="json"
-  ...  Upload Json Wallet Based On Environment  ${e_USER}
-
-Compute Suite Total Funding
-  ${t_total}=  Evaluate  ${s_REWARD_AMOUNT} + ${s_MILESTONE_AMOUNT}
-  ${t_strFunding}=  Convert To String  ${t_total}
-  Set Suite Variable  ${s_TOTAL_FUNDING}  ${t_strFunding}
-
-"${e_USER}" Submits "${e_WALLET_TYPE}" Wallet
-  "${e_USER}" Uploads "${e_WALLET_TYPE}" Wallet
-  User Submits Keystore Password
-  Wait Until Element Should Be Visible  ${MESSAGE_SIGNER_FORM}
-  User Submits Keystore Password  #sign message modal
-  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
-  Wait Until Element Should Be Visible  ${ADDRESS_INFO_SIDEBAR}
-  Click Element  ${CLOSE_ICON}
-  Wait Until Element Should Not Be Visible  ${GOVERNANCE_MODAL}
-
-#====================#
-#  SETUP / TEARDOWN  #
-#====================#
-"${e_USER}" Account Has Successfully Locked DGD
-  ${t_entry}=  Set Variable If  "${ENVIRONMENT}"=="KOVAN"
-  ...  ${KOVAN_GOVERNANCE_URL_EXT}  ${GOVERNANCE_LOGIN_URL_EXT}
-  Launch Digix Website  ${t_entry}  ${ENVIRONMENT}  ${e_USER}
-  "${e_USER}" Submits "json" Wallet To Locked DGD
-  User Should Be Able To Get Started On Governance
-  Wait And Click Element  ${GET_STARTED_BTN}
-
-"${e_USER}" Account Has Successfully Logged In To DigixDao Using "${e_WALLET_TYPE}"
-  ${t_entry}=  Set Variable If  "${ENVIRONMENT}"=="KOVAN"
-  ...  ${KOVAN_GOVERNANCE_URL_EXT}  ${GOVERNANCE_LOGIN_URL_EXT}
-  Launch Digix Website  ${t_entry}  ${ENVIRONMENT}  ${e_USER}
-  "${e_USER}" Submits "${e_WALLET_TYPE}" Wallet
+#temporary
+# Return Action Button Names On Proposal
+#   [Arguments]  ${p_action}
+#   ${t_smallCase}=  Convert To Lowercase  ${p_action}
+#   ${t_dict}=  Create Dictionary
+#   ...  endorses proposal=ENDORSE
+#   ...  abort=ABORT
+#   ...  edit=EDIT
+#   ...  finalizes proposal=FINALIZE
+#   ...  approve=APPROVE
+#   ...  claims approved proposal=CLAIM APPROVAL
+#   ...  vote=VOTE
+#   ...  reveal=REVEAL VOTE
+#   ...  claims voting result=CLAIM RESULTS
+#   ...  claims proposal funding= CLAIM FUNDING
+#   ...  sets proposal to complete=MY MILESTONE IS COMPLETED
+#   ${t_value}=  Get From Dictionary  ${t_dict}  ${t_smallCase}
+#   [Return]  ${t_value}
 
 Upload Json Wallet Based On Environment
   [Arguments]  ${p_filename}  ${p_environment}=${ENVIRONMENT}
   ${t_path}=  Normalize Path  ${CURDIR}/${KEYSTORE_PATH}/${p_environment}/${p_filename}.json
   Choose File  ${IMPORT_KEYSTORE_UPLOAD_BTN}  ${t_path}
 
-Go Back To Dashboard Page
-  Wait And Click Element  ${HOME_SIDE_MENU_ICON}
+Repeat Until Newly Created Project Is On "${e_TAB}" Tab
+  Wait Until Element Should Be Visible  ${PROPOSAL_CARD}:eq(0) h2
+  :FOR  ${index}  IN RANGE  0  5
+  \  ${t_status}=  Run Keyword And Return Status
+  ...  Wait Until Element Contains  ${PROPOSAL_CARD}:eq(0) h2  ${g_GENERIC_VALUE}  timeout=5 seconds
+  \  Run Keyword If  ${t_status}
+  ...  Exit For Loop
+  ...  ELSE  Switch "${e_TAB}" Tab To Update Content
+
+Switch "${e_TAB}" Tab To Update Content
   Wait Until Element Should Be Visible  ${GOVERNANCE_FILTER_SECTION}
+  Modify Element Attribute Via jQuery  ${GOVERNANCE_MENU}  display  none
+  Wait And Click Element  ${ARCHIVED_TAB}
+  Wait And Click Element  ${${e_TAB}_TAB}
+
+User Should Be Able To Participate On Proposal
+  Newly Created Proposal Should Be Visible On "All" Tab
+
+#====================#
+#  SETUP / TEARDOWN  #
+#====================#
+"${e_USER}" Account Has Successfully Logged In To DigixDao Using "${e_WALLET_TYPE}"
+  "${e_USER}" Launch Governance Page
+  "${e_USER}" Submits "${e_WALLET_TYPE}" Wallet
 
 "${e_USER}" Launch Governance Page
   ${t_entry}=  Set Variable If  "${ENVIRONMENT}"=="KOVAN"
   ...  ${KOVAN_GOVERNANCE_URL_EXT}  ${GOVERNANCE_LOGIN_URL_EXT}
   Launch Digix Website  ${t_entry}  ${ENVIRONMENT}  ${e_USER}
+
+#===========#
+#  HELPERS  #
+#===========#
+Get Proposal Card Index
+  Wait Until Element Should Be Visible  ${PROPOSAL_CARD}:eq(0) h2
+  @{t_elements}=  Get WebElements  ${PROPOSAL_CARD} ${VIEW_PROJECT_LINK}
+  :FOR  ${index}  ${locator}  IN ENUMERATE  @{t_elements}
+  \  ${t_text}=  Get Text  ${PROPOSAL_CARD}:eq(${index}) h2
+  \  ${t_same}=  Evaluate  '${t_text}'=='${g_GENERIC_VALUE}'
+  \  Run Keyword If  '${t_same}'=='True'  Run Keywords
+  ...  Set Suite Variable  ${s_PROPOSAL_INDEX}  ${locator}
+  ...  AND  Exit For Loop

--- a/src/resources/keywords/like_unlike_module.robot
+++ b/src/resources/keywords/like_unlike_module.robot
@@ -50,6 +50,7 @@ Comment Like Counter Should Be Correct
   ...  Compute Like Counter
   ...  ELSE  Set Variable  ${s_LATEST_COUNTER}
   ${t_strValue}=  Convert To String  ${t_value}
+  Wait Until Element Should Be Visible  ${s_COMMENT_THREAD} ${COMMENT_ACTION_CONTAINER}:eq(1)
   Wait Until Element Should Contain  ${s_COMMENT_THREAD} ${COMMENT_ACTION_CONTAINER}:eq(1)  ${t_strValue}
 
 #====================#

--- a/src/resources/keywords/profile_view_page.robot
+++ b/src/resources/keywords/profile_view_page.robot
@@ -8,9 +8,7 @@ Resource    ../variables/profile_view_constants.robot
 Pull "${e_USER}" Data From Info Server
   Wait Until Element Should Be Visible  ${ADDRESS_LABEL}
   ${t_address}=  Get Text  ${ADDRESS_LABEL}
-  ${t_url}=  Set Variable  ${${ENVIRONMENT}_INFO_URL}/address/${t_address}
-  ${t_lookup}=  Set Variable  /result/redeemedBadge
-  ${t_redeemStatus}=  Find Value On Json URL  ${t_url}  ${t_lookup}
+  ${t_redeemStatus}=  LookUp Value On Info Server  ${t_address}  /result/redeemedBadge
   Set Suite Variable  ${s_ADDRESS}  ${t_address}
   Set Suite Variable  ${s_REDEEM_STATUS}  ${t_redeemStatus}
 
@@ -32,8 +30,9 @@ Pull "${e_USER}" Data From Info Server
 
 "${e_USER}" Redeems Badge
   Wait Until Element Should Be Visible  ${PROFILE_MODERATOR_CARD}
-  Run Keyword If  ${s_REDEEM_STATUS}
+  Run Keyword If  ${s_REDEEM_STATUS}  Run Keywords
   ...  Log To Console  ${\n}"${s_ADDRESS}" already redeemed badge. Please reset servers on ${ENVIRONMENT}
+  ...  AND  FAIL  msg=Please run `bash script/restart.sh` on `dao-server` repo
   ...  ELSE  Run Keywords
   ...  Click Element  ${PROFILE_REDEEM_BADGE_BTN}
   ...  AND  User Submits Keystore Password

--- a/src/resources/keywords/proposal_view_page.robot
+++ b/src/resources/keywords/proposal_view_page.robot
@@ -1,0 +1,135 @@
+*** Settings ***
+Resource    ../variables/governance_constants.robot
+
+*** Variables ***
+# proposal
+${PROJECT_SUMMARY}  jquery=div[class*="ProjectSummary"]
+${PROPOSAL_TITLE_DIV}  ${PROJECT_SUMMARY} [class*="Title"]
+${PROPOSAL_FUNDING_DIV}  ${PROJECT_SUMMARY} [class*="FundingStatus"]
+${PROPOSAL_REWARD_DIV}  ${PROJECT_SUMMARY} [class*="Reward"] span
+${PROPOSAL_DETAILS_DIV}  jquery=[class*="DetailsContainer"]
+${PROPOSAL_SHORT_DESC_DIV}  ${PROPOSAL_DETAILS_DIV} [class*="ShortDescription"]
+${PROPOSAL_DESC_DIV}  ${PROPOSAL_DETAILS_DIV} [class*="Details"] span
+${PROPOSAL_MILESTONE_DIV}  jquery=[class*="MilestonesContainer"]
+${PROPOSAL_MILESTONE_ARROW_ICON}  ${PROPOSAL_MILESTONE_DIV} svg:last
+${PROPOSAL_MS_DESC_DIV}  ${PROPOSAL_MILESTONE_DIV} [class*="Content"]
+${PROPOSAL_MS_AMOUNT_DIV}  ${PROPOSAL_MS_DESC_DIV} > p
+${TIMER_DIV}  css=div[class*="QuorumInfoCol"]
+
+*** Keywords ***
+#========#
+#  WHEN  #
+#========#
+"${e_USER}" Approves Newly Drafted Proposal
+  Proposal Status Should Be "DRAFT"
+  Visit Newly Created Proposal And Click "Approve" Action
+  Get Remaining Time To Execute Next Step
+  Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
+  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(0)
+  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(2)
+  User Submits Keystore Password  #transaction modal
+
+"${e_USER}" Votes "${e_RESPONSE}" On Proposal
+  Newly Created Proposal Should Be Visible On "All" Tab
+  Force Element Via jQuery  ${HELP_LAUNCHER}  hide
+  Visit Newly Created Proposal And Click "Vote" Action
+  Get Remaining Time To Execute Next Step
+  Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
+  Run Keyword If  "${e_RESPONSE}"=="Yes"
+  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(0)  #Yes vote button
+  ...  ELSE IF  "${e_RESPONSE}"=="No"
+  ...  Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(1)  #No vote button
+  ${t_salt}=  Get Element Attribute  ${GOVERNANCE_SIDE_PANEL} a:eq(0)  download
+  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} a:eq(0)  #Download Json File button
+  Wait And Click Element  ${GOVERNANCE_SIDE_PANEL} button:eq(2)  #confirm commit button
+  Replace Salt File According To User Role  ${t_salt}  ${e_USER}
+  User Submits Keystore Password
+
+"${e_USER}" Reveals Vote Via Salt File
+  Newly Created Proposal Should Be Visible On "All" Tab
+  Visit Newly Created Proposal And Click "Reveal" Action
+  Get Remaining Time To Execute Next Step
+  "Upload" "${e_USER}" Salt File
+  Wait Until Element Should Be Visible  ${NOTE_CONTAINER}
+  Wait And Click Element  ${GOVERNANCE_SIDENAR_DIV} ${ROUND_BTN}
+  "Remove" "${e_USER}" Salt File
+  User Submits Keystore Password  #transaction modal
+
+"${e_USER}" Uploads Modified Salt File
+  ${t_path}=  Normalize Path  ~/Downloads/
+  ${t_content}=  Load Json From File  ${t_path}/${e_USER}${SALT_FILE_EXT}
+  ${t_vote}=  Get Value From Json  ${t_content}  vote
+  ${t_invert}=  Set Variable If  "${t_vote}"=="${true}"  false  true
+  ${t_new}=  Update Value To Json  ${t_content}  vote  ${t_invert}
+  ${t_write}=  Convert JSON To String  ${t_new}
+  Append To File  ${t_path}/${e_USER}_modified${SALT_FILE_EXT}  ${t_write}  encoding=UTF-8
+  ${t_user}=  Set Variable  ${e_USER}_modified
+  "${t_user}" Reveals Vote Via Salt File
+
+"${e_USER}" "${e_ACTION}" On Newly Created Proposal
+  Newly Created Proposal Should Be Visible On "All" Tab
+  Visit Newly Created Proposal And Click "${e_ACTION}" Action
+  User Submits Keystore Password  #transaction modal
+
+#========#
+#  THEN  #
+#========#
+Proposal Details Should Be Correct On Proposal Details Page
+  Go To Newly Created Proposal View Page
+  Wait Until Element Contains  ${PROPOSAL_TITLE_DIV}  ${g_GENERIC_VALUE}
+  Wait And Click Element  ${PROPOSAL_MILESTONE_ARROW_ICON}
+  Wait Until Element Contains  ${PROPOSAL_SHORT_DESC_DIV}  ${g_GENERIC_VALUE}
+  Wait Until Element Contains  ${PROPOSAL_DESC_DIV}  ${g_GENERIC_VALUE}
+  Wait Until Element Contains  ${PROPOSAL_MS_DESC_DIV}  ${g_GENERIC_VALUE}
+  Wait Until Element Contains  ${PROPOSAL_MS_AMOUNT_DIV}  ${s_MILESTONE_AMOUNT}
+  Wait Until Element Contains  ${PROPOSAL_REWARD_DIV}  ${s_REWARD_AMOUNT}
+  Wait Until Element Contains  ${PROPOSAL_FUNDING_DIV}  ${s_TOTAL_FUNDING}
+
+Vote Count Should Increase
+  Newly Created Proposal Should Be Visible On "All" Tab
+  # Wait And Click Element  ${PROPOSAL_CARD}:eq(0) ${VIEW_PROJECT_LINK}
+
+#=====================#
+#  INTERNAL KEYWORDS  #
+#=====================#
+Replace Salt File According To User Role
+  [Arguments]  ${p_filename}  ${p_role}
+  ${t_path}=  Normalize Path  ~/Downloads/
+  Wait Until Created  ${t_path}/${p_filename}  timeout=${g_TIMEOUT_SEC}
+  Move File  ${t_path}/${p_filename}  ${t_path}/${p_role}${SALT_FILE_EXT}
+
+"${e_ACTION}" "${e_USER}" Salt File
+  ${t_file}=  Normalize Path  ~/Downloads/${e_USER}${SALT_FILE_EXT}
+  Run Keyword If  "${e_ACTION}"=="Upload"  Run Keywords
+  ...  Wait Until Element Should Be Visible  ${GOVERNANCE_SIDE_PANEL}
+  ...  AND  Choose File  ${SALT_JSON_UPLOAD_BTN}  ${t_file}
+  ...  ELSE  Remove File  ${t_file}
+
+Get Remaining Time To Execute Next Step
+  Wait Until Element Should Be Visible  ${TIMER_DIV}
+  ${t_text}=  Get Text  ${TIMER_DIV}
+  Set Global Variable  ${g_TIMER}  ${t_text}
+
+Sleep Until Timer Runs Out
+  [Arguments]  ${p_type}=DEFAULT
+  # sample data  0D:00H:01M:29S
+  Capture Page Screenshot
+  ${t_minutes}=  Get Regexp Matches  ${g_TIMER}  (?<=H:)(.*)(?=M)
+  ${t_seconds}=  Get Regexp Matches  ${g_TIMER}  (?<=M:)(.*)(?=S)
+  ${t_numMin}=  Convert To Number  ${t_minutes[0]}
+  ${t_nummSec}=  Convert To Number  ${t_seconds[0]}
+  ${t_min}=  Evaluate  ${t_numMin} * 60
+  ${t_total}=  Evaluate  ${t_min} + ${t_nummSec}
+  ${t_div}=  Evaluate  ${t_total} / 2
+  ${t_time}=  Set Variable If  "${p_type}"=="REVEAL"
+  ...  ${t_div}  ${t_total}
+  Log To Console  ${t_time} remaining seconds to start next step
+  Sleep  ${t_time} seconds
+
+Assign ID For Interaction Buttons
+  Wait Until Element Should Be Visible  ${PROJECT_SUMMARY}
+  @{t_elements}=  Get WebElements  ${PROJECT_SUMMARY} ${ROUND_BTN}
+  :FOR  ${locator}  IN  @{t_elements}
+  \  ${t_text}=  Get Text  ${locator}
+  \  Log  ${t_text}
+  \  Assign Id To Element  ${locator}  ${t_text}

--- a/src/resources/keywords/wallet_view_page.robot
+++ b/src/resources/keywords/wallet_view_page.robot
@@ -8,7 +8,7 @@ Resource  ../variables/wallet_view_contants.robot
   ${t_claimValue}=  LookUp Value On Info Server  ${t_address}  /result/claimableDgx
   ${t_zero}=  Evaluate  ${t_claimValue} == 0
   Run Keyword If  ${t_zero}  Run Keywords
-  ...  Log To Console  ${\n}Please run `npm run teleport:next_quarter` on `dao-contracts`
+  ...  Log To Console  ${\n}Please run `npm run teleport:main_phase` on `dao-contracts`
   ...  AND  Log To Console  ${\n}then Restart info-server
   ...  AND  Fail  msg=Please run command on dao-contracts and restart info-server
   ...  ELSE  Run Keywords

--- a/src/resources/variables/governance_constants.robot
+++ b/src/resources/variables/governance_constants.robot
@@ -15,48 +15,27 @@ ${DAO_TOUR_SIDE_MENU_ICON}  css=div[kind="product"]
 ...  ${HISTORY_SIDE_MENU_ICON}  @{LOGGED_OUT_SIDENAV_LIST}
 
 # user profile stats
-${DASHBOARD_STATS_DIV}  jquery=[class*="timeline"] + [class*="Container"]
-${STAT_QUARTER_POINT}  ${DASHBOARD_STATS_DIV} [class*="Point"]:eq(0) span
-${STAT_REPUTATION_POINT}  ${DASHBOARD_STATS_DIV} [class*="Point"]:eq(1) span
-${STAT_MYSTAKE_POINT}  ${DASHBOARD_STATS_DIV} [class*="Point"]:eq(2) span
+${DASHBOARD_STATS_DIV}    jquery=[class*="timeline"] + [class*="Container"]
+${STAT_QUARTER_POINT}     css=[data-digix="Dashboard-Stats-QuarterPoints"]
+${STAT_REPUTATION_POINT}  css=[data-digix="Dashboard-Stats-ReputationPoints"]
+${STAT_MYSTAKE_POINT}     css=[data-digix="Dashboard-Stats-Stake"]
 
 #generic
 ${SNACK_BAR_DIV}  jquery=div[class*="SnackbarContainer"]
 ${ROUND_BTN}  button[class*="RoundBtn"]
-${TIMER_DIV}  css=div[class*="QuorumInfoCol"]
-${GOVERNANCE_MENU}  css=section[class*="HeaderWrapper"]
 ${GOVERNANCE_SIDENAR_DIV}  jquery=div[class*="IntroContainer"]
-${GOVERNANCE_BTN}  button[class*="RoundBtn"]
 ${GOVERNANCE_SIDE_PANEL}  ${GOVERNANCE_SIDENAR_DIV}
 #header
-${HEADER_LOCK_DGD_BTN}  ${GOVERNANCE_MENU} [class*="WalletWrapper"] button
+${GOVERNANCE_MENU}  css=section[class*="HeaderWrapper"]
+${HEADER_LOCK_DGD_BTN}  css=[data-digix="Header-LockDgd"]
 ${ADDRESS_LABEL}  ${GOVERNANCE_MENU} div[class*="AddressLabel"]
+${LOAD_WALLET_BTN}  css=[data-digix="Header-LoadWallet"]
+
+#------------------------------------#
 #modal
-# ${MODAL_ACTIONS}  jquery=div[class*="MuiDialogActions-root"]
 ${GOVERNANCE_MODAL}  jquery=div[role="document"]
 ${MODAL_ACTIONS}  ${GOVERNANCE_MODAL} > div:last
-
-# sidebar
-${CLOSE_ICON}  jquery=[class*="CloseButton"] svg
-${LOAD_WALLET_BTN}  ${GOVERNANCE_MENU} ${GOVERNANCE_BTN}
-${LOAD_WALLET_SIDEBAR_BUTTON}  ${GOVERNANCE_SIDENAR_DIV} ${GOVERNANCE_BTN}
-${ADDRESS_INFO_SIDEBAR}  css=[class*="AddressInfo"]
-${LOCK_DGD_BTN}  jquery=[class*="style__InnerContainer"] button:eq(1)
-${LOCK_DGD_AMOUNT_FIELD}  css=div[class*="InputDgxBox"] input[type="number"]
-${LOCK_DGD_STATUS}  css=p[class*="StakeCaption"]
-${LOCK_WITH_AMOUNT_BTN}  css=div[class*="InputDgxBox"] ~ button
-${CONGRATULATION_BANNER}  css=div[class*="ConfirmationBox"]
-${GET_STARTED_BTN}  ${CONGRATULATION_BANNER} + button
-${SALT_JSON_UPLOAD_BTN}  css=#json-upload
-${NOTE_CONTAINER}  css=div[class*="NoteContainer"]
-# wallet type
-${WALLET_METAMASK_BTN}  div[kind="metamask"]
-${WALLET_LEDGER_BTN}  div[kind="ledger"]
-${WALLET_TREZOR_BTN}  div[kind="trezor"]
-${WALLET_IMTOKEN_BTN}  div[kind="imtoken"]
-${WALLET_JSON_BTN}  div[kind="json"]
 # import wallet modal
-# ${IMPORT_KEYSTORE_ICON}  svg[class*="ImportKeystore-walletIcon"]
 ${IMPORT_KEYSTORE_ICON}  css=#alert-dialog-title
 ${IMPORT_KEYSTORE_UPLOAD_BTN}  ${IMPORT_KEYSTORE_ICON} + div input[type="file"]
 ${IMPORT_PASSWORD_FIELD}  css=input[id="name-simple"][type="password"]
@@ -64,13 +43,31 @@ ${UNLOCK_WALLET_BTN}  ${MODAL_ACTIONS} button:eq(1)
 # sign message modal
 ${MESSAGE_SIGNER_FORM}  ${GOVERNANCE_MODAL} form
 ${SIGN_MESSAGE_BTN}  ${UNLOCK_WALLET_BTN}
-#---------------------------#
-#governance body
-${GOVERNANCE_BODY}  jquery=div[class*="ContentWrapper"]
-${GOVERNANCE_CREATE_BTN}  css=a[href="#/proposals/create"] button
-${CREATE_NOW_BTN}  ${PROPOSAL_MENU_NEXT_BTN}
-${PROPOSAL_SUBMIT_BTN}  ${GOVERNANCE_BODY} button:eq(1)
-# filter tabs
+
+#------------------------------------#
+# sidebar
+${CLOSE_ICON}  jquery=[class*="CloseButton"] svg
+${LOAD_WALLET_SIDEBAR_BUTTON}  ${GOVERNANCE_SIDENAR_DIV} ${ROUND_BTN}
+${ADDRESS_INFO_SIDEBAR}  css=[class*="AddressInfo"]
+${LOCK_DGD_BTN}  jquery=[class*="style__InnerContainer"] button:eq(1)
+${LOCK_DGD_AMOUNT_FIELD}  css=[data-digix="LockDgdOverlay-DgdAmount"]
+${LOCK_DGD_STATUS}  css=p[class*="StakeCaption"]
+${LOCK_WITH_AMOUNT_BTN}  css=[data-digix="LockDgdOverlay-LockDgd"]
+${CONGRATULATION_BANNER}  css=div[class*="ConfirmationBox"]
+${GET_STARTED_BTN}  ${CONGRATULATION_BANNER} + button
+${SALT_JSON_UPLOAD_BTN}  css=#json-upload
+${NOTE_CONTAINER}  css=div[class*="NoteContainer"]
+
+#------------------------------------#
+# wallet type
+${WALLET_METAMASK_BTN}  div[kind="metamask"]
+${WALLET_LEDGER_BTN}  div[kind="ledger"]
+${WALLET_TREZOR_BTN}  div[kind="trezor"]
+${WALLET_IMTOKEN_BTN}  div[kind="imtoken"]
+${WALLET_JSON_BTN}  div[kind="json"]
+
+#------------------------------------#
+# dashboard filter tabs
 ${GOVERNANCE_FILTER_SECTION}  jquery=div[class*="FilterWrapper"]
 ${ALL_TAB}  ${GOVERNANCE_FILTER_SECTION} a:eq(1)
 ${IDEA_TAB}  ${GOVERNANCE_FILTER_SECTION} a:eq(2)
@@ -79,36 +76,8 @@ ${PROPOSAL_TAB}  ${GOVERNANCE_FILTER_SECTION} a:eq(4)
 ${ONGOING_TAB}  ${GOVERNANCE_FILTER_SECTION} a:eq(5)
 ${REVIEW_TAB}  ${GOVERNANCE_FILTER_SECTION} a:eq(6)
 ${ARCHIVED_TAB}  ${GOVERNANCE_FILTER_SECTION} a:eq(7)
-# proposal container
+
+# proposal card container
 ${PROPOSAL_CARD}  jquery=div[class*="ProposalWrapper"]
 ${VIEW_PROJECT_LINK}  a[class*="ProposalLink"]
 ${PROPOSAL_STATUS_BTN}  button[class*="FlatBtn"]
-${PARTICIPATE_BTN}  button[class*="RoundBtn"]
-# create proposal fields
-${PROPOSAL_TAB_PANEL}  jquery=div[class*="TabPanel"]
-${PROPOSAL_MENU}  ${PROPOSAL_TAB_PANEL} +  [class*="Header"] > div:eq(1)
-${PROPOSAL_MENU_PREVIEW_BTN}  ${PROPOSAL_MENU} button:eq(0)
-${PROPOSAL_MENU_PREVIOUS_BTN}  ${PROPOSAL_MENU} button:eq(1)
-${PROPOSAL_MENU_NEXT_BTN}  ${PROPOSAL_MENU} button:eq(2)
-${PROJECT_TITLE_FIELD}  css=input[id="title"]
-${PROJECT_DESC_FIELD}  css=textarea[id="description"]
-${PROJECT_INFO_FIELD}  css=#details .ql-editor
-${UPLOAD_IMAGE_BTN}  css=[class*="UploadButton"]
-${IMAGE_UPLOAD_BTN}  css=input[id="image-upload"][type="file"]
-${REWARD_FIELD}  css=input[id="finalReward"]
-${NUM_OF_MILESTONE_FIELD}  css=select[id="noOfMilestones"]
-${MILESTONE_FORM}  jquery=div[class*="CreateMilestone"]
-${MILESTONE_FIELD}  ${MILESTONE_FORM} input
-${MILESTONE_DESC_FIELD}  ${MILESTONE_FORM} textarea
-# proposal
-${PROJECT_SUMMARY}  jquery=div[class*="ProjectSummary"]
-${PROPOSAL_TITLE_DIV}  ${PROJECT_SUMMARY} [class*="Title"]
-${PROPOSAL_FUNDING_DIV}  ${PROJECT_SUMMARY} [class*="FundingStatus"]
-${PROPOSAL_REWARD_DIV}  ${PROJECT_SUMMARY} [class*="Reward"] span
-${PROPOSAL_DETAILS_DIV}  jquery=[class*="DetailsContainer"]
-${PROPOSAL_SHORT_DESC_DIV}  ${PROPOSAL_DETAILS_DIV} [class*="ShortDescription"]
-${PROPOSAL_DESC_DIV}  ${PROPOSAL_DETAILS_DIV} [class*="Details"] span
-${PROPOSAL_MILESTONE_DIV}  jquery=[class*="MilestonesContainer"]
-${PROPOSAL_MILESTONE_ARROW_ICON}  ${PROPOSAL_MILESTONE_DIV} svg:last
-${PROPOSAL_MS_DESC_DIV}  ${PROPOSAL_MILESTONE_DIV} [class*="Content"]
-${PROPOSAL_MS_AMOUNT_DIV}  ${PROPOSAL_MS_DESC_DIV} > p

--- a/src/suite/functional/DaoClaimRewardTest.robot
+++ b/src/suite/functional/DaoClaimRewardTest.robot
@@ -14,6 +14,9 @@ User Has Successfully Claimed Rewards On Wallet Page
   When User Goes To "Wallet" View Page
   And "rewardee" Claims Reward
   Then User Should Be Successfully Claimed Reward
+  When Go Back To Dashboard Page
+  And User Goes To "Wallet" View Page
+  Then User Should Be Successfully Claimed Reward
 
 Claimed Reward User Has Successfully Visited Wallet Page
   [Setup]  "rewardee" Account Has Successfully Logged In To DigixDao Using "json"

--- a/src/suite/functional/DaoCommentModuleTest.robot
+++ b/src/suite/functional/DaoCommentModuleTest.robot
@@ -30,25 +30,27 @@ Proposer Has Successfully Sorted Main Thread From Oldest
 
 Proposer Has Successfully Posted Multiple Comments
   Given User Is In "PROPOSAL_VIEW" Page
-  WHEN "proposer" Posts Multiple "REPLIES" To Thread "1"
+  When "proposer" Posts Multiple "REPLIES" To Thread "1"
   Then All Comments Should Be Visible
 
 Proposer Has Successfully Posted Multiple Nested Comments
   Given User Is In "PROPOSAL_VIEW" Page
-  WHEN "proposer" Posts Multiple "NESTED_REPLIES" To Thread "2"
+  When "proposer" Posts Multiple "NESTED_REPLIES" To Thread "2"
   Then All Comments Should Be Visible
 
-# Proposer Has Successfully Showed All Comments
-#   [Setup]  User Revisits Newly Created Proposal
-#   Given User Is In "PROPOSAL_VIEW" Page
-#   When "proposer" Sorts Main Thread From "Oldest"
-#   And User Shows All Main Thread Comments
-#   Then All Thread Comments Should Be Visible
-#   When "proposer" Sorts Main Thread From "Latest"
-#   And User Shows All "REPLIES" Comments
-#   Then All Comments Should Be Visible
-#   When User Shows All "NESTED_REPLIES" Comments
-#   Then All Comments Should Be Visible
+Proposer Has Successfully Showed All Comments
+  [Setup]  User Revisits Newly Created Proposal
+  Given User Is In "PROPOSAL_VIEW" Page
+  When "proposer" Sorts Main Thread From "Oldest"
+  Then Main Thread Should Be Sorted
+  When User Shows All Main Thread Comments
+  Then All Thread Comments Should Be Visible
+  When "proposer" Sorts Main Thread From "Latest"
+  Then Main Thread Should Be Sorted
+  When User Shows All "REPLIES" Comments
+  Then All Comments Should Be Visible
+  When User Shows All "NESTED_REPLIES" Comments
+  Then All Comments Should Be Visible
 
 Proposer Has Successfully Deleted A Comment
   Given User Is In "PROPOSAL_VIEW" Page

--- a/src/suite/functional/DaoRedeemBadgeTest.robot
+++ b/src/suite/functional/DaoRedeemBadgeTest.robot
@@ -16,6 +16,9 @@ Badge Holder Has Successfully Redeemed Badge
   When "badgeHolder" Marks Himself As Participant
   And "badgeHolder" Redeems Badge
   Then Badge Should Be Successfully Redeemed
+  When Go Back To Dashboard Page
+  And User Goes To "Profile" View Page
+  Then Badge Should Be Successfully Redeemed
 
 Redeemed Badge User Has Successfully Visited Profile Page
   [Setup]  "badgeHolder" Account Has Successfully Logged In To DigixDao Using "json"


### PR DESCRIPTION
Tracker: DT-53

Changes:
- fix intermittent issue on CommentModuleTest and DaoLikeModuleTest
- force fail DaoClaimRewardTest when account is already redeem badge and show on log that user should run `bash scripts/restart.sh`
- add switch tab assertion for both DaoClaimRewardTest and DaoRedeemBadgeTest after claiming rewards or redeeming badge.
- updated the instruction on how to make account make some rewards points 
- major refactor (move keywords on respective module instead of having it on governance_page.robot file) 
```
newly created files 
- create_edit_proposal_page.robot
- proposal_view_page.robot
```
