### PR TITLE
included assertion of overlay on KYCETest

### DIFF
--- a/src/resources/keywords/create_edit_proposal_page.robot
+++ b/src/resources/keywords/create_edit_proposal_page.robot
@@ -24,10 +24,21 @@ ${CREATE_NOW_BTN}   css=[data-digix="Create-Proposal-Button"]
 ${PROPOSAL_SUBMIT_BTN}  jquery=[class*="CTA"] button:eq(1)
 #Preview
 ${CONTINUE_EDITING_BTN}  css=[class*="ProposalsWrapper"] button
+#error overlay
+${ERROR_OVERLAY_CONTAINER}  css=[data-digix="ProjectError-Notification"]
+${ERROR_CARD_TITLE}  css=[data-digix="ProjectError-Notification-Title"]
+${ERROR_OVERLAY_RETURN_BTN}  css=[data-digix="ProjectError-Return"]
+${ERROR_KYC_NOT_APPROVED_MSG}  KYC IS NOT VALID
+
 *** Keywords ***
 #========#
 #  WHEN  #
 #========#
+"${e_USER}" Ticks Create Button On Dashboard Page
+  Wait And Click Element  ${GOVERNANCE_CREATE_BTN}
+
+User Closes Error Overlay
+  Wait And Click Element  ${ERROR_OVERLAY_RETURN_BTN}
 "${e_USER}" Creates A Governance Propsosal
   User Goes To Create Proposal Page
   User Submit Proposal Details
@@ -49,6 +60,14 @@ User Submit Proposal Details
   User Submits Milestone Details  ${p_reward}  ${p_milestone}  ${g_GENERIC_VALUE}
   #prevew
   User Submits Proposal Details
+
+#========#
+#  THEN  #
+#========#
+Error Overlay Should "${e_ACTION}" Visible
+  Run Keyword  Wait Until Element Should ${e_ACTION} Visible  ${ERROR_OVERLAY_RETURN_BTN}
+  Run Keyword If  '${e_ACTION.lower()}'!='not be'
+  ...  Wait Until Element Should Contain  ${ERROR_CARD_TITLE}  ${ERROR_KYC_NOT_APPROVED_MSG}
 
 #=====================#
 #  INTERNAL KEYWORDS  #

--- a/src/resources/keywords/kyc_submission_module.robot
+++ b/src/resources/keywords/kyc_submission_module.robot
@@ -8,6 +8,7 @@ Resource  ../variables/kyc_submission_constants.robot
 #========#
 User Submits KYC Details For Approval
   [Arguments]  ${p_unique}=NONE
+  Hide SnackBar
   Genearate Dates
   ${t_unique}=  Run Keyword If  '${p_unique}'=='NONE'
   ...  Get Time  epoch

--- a/src/suite/endtoend/DaoKYCETest.robot
+++ b/src/suite/endtoend/DaoKYCETest.robot
@@ -6,18 +6,34 @@ Default Tags    DaoKYCETest  notForKovan
 Suite Teardown    Close All Browsers
 Resource  ../../resources/common/web_helper.robot
 Resource  ../../resources/keywords/governance_page.robot
+Resource  ../../resources/keywords/create_edit_proposal_page.robot
 Resource  ../../resources/keywords/profile_view_page.robot
 Resource  ../../resources/keywords/kyc_submission_module.robot
 Resource  ../../resources/keywords/kyc_admin_page.robot
 
 *** Test Cases ***
-NonKycUser Has Successfully Submitted KYC Details On Profile Page
+NonKycUser Has Sucessfully Viewed Error Overlay When Creating Proposal
   [Setup]  Run keywords  "nonKYCUser" Account Has Successfully Logged In To DigixDao Using "json"
   ...  Generate Suite Unique Value
+  Given User Is In "GOVERNANCE" Page
+  When "NonKycUser" Ticks Create Button On Dashboard Page
+  Then Error Overlay Should "BE" Visible
+  When User Closes Error Overlay
+  Then Error Overlay Should "NOT BE" Visible
+
+NonKycUser Has Successfully Submitted KYC Details On Profile Page
   Given User Is In "GOVERNANCE" Page
   When User Goes To "Profile" View Page
   And User Submits KYC Details For Approval  ${s_UNIQUE}
   Then Kyc Status Should Be "Pending"
+
+NonKycUser Has Successfully Viewed Error Overlay
+  [Setup]  Go Back To Dashboard Page
+  Given User Is In "GOVERNANCE" Page
+  When "NonKycUser" Ticks Create Button On Dashboard Page
+  Then Error Overlay Should "BE" Visible
+  When User Closes Error Overlay
+  Then Error Overlay Should "NOT BE" Visible
 
 KYCOfficer Has Successfully Rejected KYC Account
   [Setup]  "kycOfficer" Account Has Successfully Logged In To DigixDao Using "json"
@@ -27,10 +43,17 @@ KYCOfficer Has Successfully Rejected KYC Account
   And User "Rejects" "${s_UNIQUE}" Account
   Then Account Status Should Be "REJECTED"
 
-NonKycUser Has Successfully Resubmitted KYC Details On Profile Page
+NonKycUser Has Successfully Viewed Error Overlay
   [Setup]  Run Keywords  Switch Browser  nonKYCUser
   ...  AND  Go Back To Dashboard Page
-  ...  AND  Generate Suite Unique Value
+  Given User Is In "GOVERNANCE" Page
+  When "NonKycUser" Ticks Create Button On Dashboard Page
+  Then Error Overlay Should "BE" Visible
+  When User Closes Error Overlay
+  Then Error Overlay Should "NOT BE" Visible
+
+NonKycUser Has Successfully Resubmitted KYC Details On Profile Page
+  [Setup]  Generate Suite Unique Value
   Given User Is In "GOVERNANCE" Page
   When User Goes To "Profile" View Page
   Then Kyc Status Should Be "Rejected"
@@ -51,3 +74,11 @@ NonKycUser Has Successfully Set KYC Status To Approved
   Given User Is In "GOVERNANCE" Page
   When User Goes To "Profile" View Page
   Then Kyc Status Should Be "Approved"
+
+NonKycUser Has Successfully Created A Proposal
+  [Setup]  Go Back To Dashboard Page
+  Given User Is In "GOVERNANCE" Page
+  When "NonKycUser" Creates A Governance Propsosal
+  Then User Should Be Redirected To "GOVERNANCE" Page
+  And Newly Created Proposal Should Be Visible On "Idea" Tab
+  And Proposal Status Should Be "IDEA"


### PR DESCRIPTION
Target
- assert errorOverlay after logging in nonKYC account
- after submitting the kyc details for approval, assert error overlay when hitting create butotn on dashboard page
- assert errorOverlay when kycAdmin rejects KYC
- user should be able to create a proposal after KYCAdmin approves the KYC Details of the user. 