### PR TITLE
added scenario where user can locked dgd on header, wallet page, and profile page(moderator card)

### DIFF
--- a/src/resources/keywords/common_keywords.robot
+++ b/src/resources/keywords/common_keywords.robot
@@ -25,3 +25,19 @@ Upload Json Wallet Based On Environment
   [Arguments]  ${p_filename}  ${p_environment}=${ENVIRONMENT}
   ${t_path}=  Normalize Path  ${CURDIR}/${KEYSTORE_PATH}/${p_environment}/${p_filename}.json
   Choose File  ${IMPORT_KEYSTORE_UPLOAD_BTN}  ${t_path}
+
+User Locks DGD on "${e_ENTRY_POINT}"
+  ${t_entry_btn}=  Set Variable If
+  ...  '${e_ENTRY_POINT.lower()}'=='header'  ${HEADER_LOCK_DGD_BTN}
+  ...  '${e_ENTRY_POINT.lower()}'=='wallet'  ${WALLET_LOCKED_DGD_BTN}
+  ...  '${e_ENTRY_POINT.lower()}'=='profile'  ${PROFILE_LOCKED_DGD_BTN}
+  ${t_dgd_value}=  LookUp Value On Info Server  ${s_ADDRESS}  /result/lockedDgd
+  Set Suite Variable  ${s_LOCKED_DGD}  ${t_dgd_value}
+  Wait And Click Element  ${t_entry_btn}
+  User Submits Locked Stake
+
+Locked DGD Value Should Increase
+  ${t_previous_value}=  Convert To Integer  ${s_LOCKED_DGD}
+  ${t_current_value}=  Evaluate  ${t_previous_value} + ${s_LOCkED_AMOUNT_DGD}
+  ${t_str}=  Convert To String  ${t_current_value}
+  Wait Until Element Should Contain  ${STAT_LOCKED_DGD_POINT}  ${t_str}

--- a/src/resources/keywords/governance_page.robot
+++ b/src/resources/keywords/governance_page.robot
@@ -48,6 +48,7 @@ User Submits Locked Stake
   Wait Until Element Should Be Visible  ${LOCK_DGD_STATUS}
   ${t_stake}=  Return Stake Value Based On Inputted DGD Amount
   Set Suite Variable  ${s_LOCK_STAKE}  ${t_stake}
+  Set Suite Variable  ${s_LOCkED_AMOUNT_DGD}  ${p_amount}
   Wait And Click Element  ${LOCK_WITH_AMOUNT_BTN}
   User Submits Keystore Password
 

--- a/src/resources/variables/profile_view_constants.robot
+++ b/src/resources/variables/profile_view_constants.robot
@@ -8,6 +8,7 @@ ${PROFILE_MODERATOR_CARD}     css=[data-digix="Profile-ModerationRequirements"]
 ${PROFILE_REMAINING_REPUTATION}  css=[data-digix="Profile-ModerationRequirements-Reputation"]
 ${PROFILE_REMAINING_STAKE}    css=[data-digix="Profile-ModerationRequirements-Stake"]
 ${PROFILE_REDEEM_BADGE_BTN}  css=[data-digix="redeemBadgeButton"]
+${PROFILE_LOCKED_DGD_BTN}  css=[data-digix="Profile-LockMoreDgd-Cta"]
 ${PROFILE_SET_EMAIL_KYC_BTN}  css=[data-digix="Profile-KycStatus-SetEmail"]
 ${PROFILE_SUBMIT_KYC_BTN}  css=[data-digix="Profile-KycStatus-Submit"]
 

--- a/src/suite/integration/DaoCreateWalletRedeemBageTest.robot
+++ b/src/suite/integration/DaoCreateWalletRedeemBageTest.robot
@@ -7,6 +7,7 @@ Suite Teardown    Run Keywords  Removed Created Json Wallet  AND  Close All Brow
 Resource  ../../resources/common/web_helper.robot
 Resource  ../../resources/common/eth_helper.robot
 Resource  ../../resources/keywords/governance_page.robot
+Resource  ../../resources/keywords/wallet_view_page.robot
 Resource  ../../resources/keywords/profile_view_page.robot
 
 *** Variable ***
@@ -44,3 +45,26 @@ User Has Successfully Redeemed Badge
   When Go Back To Dashboard Page
   And User Goes To "Profile" View Page
   Then Redeem Badge Should Be Disabled
+
+User Has Successfully Locked DGD on Wallet Page
+  [Setup]  Go Back To Dashboard Page
+  Given User Is In "GOVERNANCE" Page
+  When User Goes To "Wallet" View Page
+  And Pull "${WALLET_NAME}" Data From Info Server
+  And User Locks DGD on "Wallet"
+  And Go Back To Dashboard Page
+  Then Locked DGD Value Should Increase
+
+User Has Successfully Locked DGD on Header
+  [Setup]  Go Back To Dashboard Page
+  Given User Is In "GOVERNANCE" Page
+  When User Locks DGD on "Header"
+  Then Locked DGD Value Should Increase
+
+User Has Successfully Locked DGD on Moderator Card On Profile Page
+  [Setup]  Go Back To Dashboard Page
+  Given User Is In "GOVERNANCE" Page
+  When User Goes To "Profile" View Page
+  And User Locks DGD on "Profile"
+  And Go Back To Dashboard Page
+  Then Locked DGD Value Should Increase


### PR DESCRIPTION
Target: Add locking dgd scenario in different entry points
- header
- profile page (moderator card)
- wallet page

Affected File: 
DaoCreateWalletRedeemBageTest.robot

Test cases added:
```
User Has Successfully Locked DGD on Wallet Page
  [Setup]  Go Back To Dashboard Page
  Given User Is In "GOVERNANCE" Page
  When User Goes To "Wallet" View Page
  And Pull "${WALLET_NAME}" Data From Info Server
  And User Locks DGD on "Wallet"
  And Go Back To Dashboard Page
  Then Locked DGD Value Should Increase

User Has Successfully Locked DGD on Header
  [Setup]  Go Back To Dashboard Page
  Given User Is In "GOVERNANCE" Page
  When User Locks DGD on "Header"
  Then Locked DGD Value Should Increase

User Has Successfully Locked DGD on Moderator Card On Profile Page
  [Setup]  Go Back To Dashboard Page
  Given User Is In "GOVERNANCE" Page
  When User Goes To "Profile" View Page
  And User Locks DGD on "Profile"
  And Go Back To Dashboard Page
  Then Locked DGD Value Should Increase
```